### PR TITLE
Add MIT license, update README badges, and set license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pbi-agent contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@
 
 *Transform data into decisions.*
 
-[![Publish Python Package](https://github.com/nasirus/pbi-agent/actions/workflows/publish.yml/badge.svg)](https://github.com/nasirus/pbi-agent/actions/workflows/publish.yml)
-[![Create GitHub Release](https://github.com/nasirus/pbi-agent/actions/workflows/release.yml/badge.svg)](https://github.com/nasirus/pbi-agent/actions/workflows/release.yml)
+[![Publish](https://img.shields.io/github/actions/workflow/status/nasirus/pbi-agent/publish.yml?label=publish)](https://github.com/nasirus/pbi-agent/actions/workflows/publish.yml)
+[![Release](https://img.shields.io/github/actions/workflow/status/nasirus/pbi-agent/release.yml?label=release)](https://github.com/nasirus/pbi-agent/actions/workflows/release.yml)
+[![Python](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/license-MIT-gold)](LICENSE)
 
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "pbi-agent"
 version = "0.0.4"
 description = "Multi-provider LLM CLI agent for editing Power BI reports"
 readme = "README.md"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "python-dotenv==1.2.2",


### PR DESCRIPTION
### Motivation
- Add a clear open-source license and update package metadata and README badges to improve clarity for users and package consumers.

### Description
- Add a `LICENSE` file containing the MIT license and copyright attribution.
- Replace several README badges with shields and add Python and License badges in `README.md`.
- Set `license = "MIT"` in `pyproject.toml` to expose license metadata for packaging tools.

### Testing
- No automated tests were modified or added in this change.
- No test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7471c190833089cb61c7cf1df993)