### PR TITLE
docs: switch installation instructions to `uv tool install` and add shell/update notes

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -21,7 +21,17 @@ outline: [2, 3]
 ## Install from PyPI
 
 ```bash
-pip install pbi-agent
+uv tool install pbi-agent
+```
+
+::: warning
+If this is your first `uv tool install`, reload your shell before running `pbi-agent` or the command may not be on your `PATH` yet.
+:::
+
+To update an existing installation later, run:
+
+```bash
+uv tool upgrade pbi-agent
 ```
 
 ## Install from Source
@@ -38,7 +48,7 @@ uv sync
 uv run pbi-agent --help
 ```
 
-If you installed the package globally with `pip`, use `pbi-agent --help` instead.
+If you installed the package with `uv tool install`, you can also verify it with `pbi-agent --help`.
 
 ## Quick Start
 


### PR DESCRIPTION
### Motivation
- Update the installation guide to reflect using the `uv` toolchain for installing and managing the CLI instead of recommending `pip`, and clarify first-run environment behavior.

### Description
- Replaced the `pip install pbi-agent` instruction with `uv tool install pbi-agent` in `docs/guide/installation.md`.
- Added a warning to reload the shell after the first `uv tool install` so the installed tool appears on `PATH`.
- Added an update instruction using `uv tool upgrade pbi-agent` and adjusted the verification wording to reference `uv run` usage.
- Kept source installation instructions and the quick start examples intact while updating related notes and formatting.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf0a5b830483309c2133a3ba10f27f)