### PR TITLE
docs: refresh provider model defaults

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -37,13 +37,13 @@ CLI
 
 ## Supported Providers
 
-| Provider | API Shape | Default Endpoint | Default Model |
-| --- | --- | --- | --- |
-| OpenAI | Responses API | `https://api.openai.com/v1/responses` | `gpt-5.4-2026-03-05` |
-| xAI | Responses API | `https://api.x.ai/v1/responses` | `grok-4-1-fast-reasoning` |
-| Google | Interactions API | `https://generativelanguage.googleapis.com/v1beta/interactions` | `gemini-3.1-flash-lite-preview` |
-| Anthropic | Messages API | `https://api.anthropic.com/v1/messages` | `claude-opus-4-6` |
-| Generic | Chat Completions API | `https://openrouter.ai/api/v1/chat/completions` | none; the `model` field is omitted when unset |
+| Provider | API Shape | Default Endpoint | Default Model | Default Sub-Model |
+| --- | --- | --- | --- | --- |
+| OpenAI | Responses API | `https://api.openai.com/v1/responses` | `gpt-5.4` | `gpt-5.4-mini` |
+| xAI | Responses API | `https://api.x.ai/v1/responses` | `grok-4.20` | `grok-4-1-fast` |
+| Google | Interactions API | `https://generativelanguage.googleapis.com/v1beta/interactions` | `gemini-3.1-pro-preview` | `gemini-3-flash-preview` |
+| Anthropic | Messages API | `https://api.anthropic.com/v1/messages` | `claude-opus-4-6` | `claude-sonnet-4-6` |
+| Generic | Chat Completions API | `https://openrouter.ai/api/v1/chat/completions` | none; the `model` field is omitted when unset | none |
 
 ::: details Conversation history mode
 OpenAI, xAI, and Google keep conversation state server-side by passing a previous response or interaction ID. Anthropic and Generic keep history client-side by re-sending accumulated messages on each turn.

--- a/docs/guide/providers.md
+++ b/docs/guide/providers.md
@@ -11,17 +11,17 @@ Provider selection resolves in this order: `--provider`, then `PBI_AGENT_PROVIDE
 
 For provider-scoped settings such as API key, model, retry limits, and token limits, resolution prefers CLI flags, then environment variables, then the saved config for the selected provider, then provider defaults. API keys still fall back to the provider-specific environment variable before saved config.
 
-`sub_agent` uses the same provider as the parent session. Its model defaults to the main `--model`, but you can override it independently with `--sub-agent-model` or `PBI_AGENT_SUB_AGENT_MODEL`.
+`sub_agent` uses the same provider as the parent session. Its sub-model defaults to a provider-specific sub-agent model from `config.py`, and you can override it independently with `--sub-agent-model` or `PBI_AGENT_SUB_AGENT_MODEL`.
 
 ## Provider Matrix
 
-| Provider | API Shape | Default Endpoint | Default Model | Env Var for Key | Image Input |
-| --- | --- | --- | --- | --- | --- |
-| OpenAI | Responses API | `https://api.openai.com/v1/responses` | `gpt-5.4-2026-03-05` | `OPENAI_API_KEY` | yes |
-| xAI | Responses API | `https://api.x.ai/v1/responses` | `grok-4-1-fast-reasoning` | `XAI_API_KEY` | no in this build |
-| Google | Interactions API | `https://generativelanguage.googleapis.com/v1beta/interactions` | `gemini-3.1-flash-lite-preview` | `GEMINI_API_KEY` | yes |
-| Anthropic | Messages API | `https://api.anthropic.com/v1/messages` | `claude-opus-4-6` | `ANTHROPIC_API_KEY` | yes |
-| Generic | Chat Completions API | `https://openrouter.ai/api/v1/chat/completions` | none | `GENERIC_API_KEY` | no in this build |
+| Provider | API Shape | Default Endpoint | Default Model | Default Sub-Model | Env Var for Key | Image Input |
+| --- | --- | --- | --- | --- | --- | --- |
+| OpenAI | Responses API | `https://api.openai.com/v1/responses` | `gpt-5.4` | `gpt-5.4-mini` | `OPENAI_API_KEY` | yes |
+| xAI | Responses API | `https://api.x.ai/v1/responses` | `grok-4.20` | `grok-4-1-fast` | `XAI_API_KEY` | no in this build |
+| Google | Interactions API | `https://generativelanguage.googleapis.com/v1beta/interactions` | `gemini-3.1-pro-preview` | `gemini-3-flash-preview` | `GEMINI_API_KEY` | yes |
+| Anthropic | Messages API | `https://api.anthropic.com/v1/messages` | `claude-opus-4-6` | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | yes |
+| Generic | Chat Completions API | `https://openrouter.ai/api/v1/chat/completions` | none | none | `GENERIC_API_KEY` | no in this build |
 
 Image input covers both explicit user attachments (`run --image`, `/image add`) and model-initiated local image inspection through the `read_image` tool.
 
@@ -40,7 +40,8 @@ The CLI also accepts provider-specific hidden aliases that map to `--api-key`: `
 | Select it | `--provider openai` or `PBI_AGENT_PROVIDER=openai` |
 | API key | `--api-key`, `PBI_AGENT_API_KEY`, or `OPENAI_API_KEY` |
 | Endpoint override | `--responses-url` or `PBI_AGENT_RESPONSES_URL` |
-| Default model | `gpt-5.4-2026-03-05` |
+| Default model | `gpt-5.4` |
+| Default sub-model | `gpt-5.4-mini` |
 | Model override | `--model` or `PBI_AGENT_MODEL` |
 | History mode | Server-side via `previous_response_id` |
 | Image input | Supported |
@@ -57,7 +58,8 @@ uv run pbi-agent --provider openai console
 | Select it | `--provider xai` or `PBI_AGENT_PROVIDER=xai` |
 | API key | `--api-key`, `PBI_AGENT_API_KEY`, or `XAI_API_KEY` |
 | Endpoint override | `--responses-url` or `PBI_AGENT_RESPONSES_URL` |
-| Default model | `grok-4-1-fast-reasoning` |
+| Default model | `grok-4.20` |
+| Default sub-model | `grok-4-1-fast` |
 | Model override | `--model` or `PBI_AGENT_MODEL` |
 | History mode | Server-side via `previous_response_id` |
 | Image input | Not enabled in this build |
@@ -74,14 +76,15 @@ uv run pbi-agent --provider xai run --prompt "List the report pages in this PBIP
 | Select it | `--provider google` or `PBI_AGENT_PROVIDER=google` |
 | API key | `--api-key`, `PBI_AGENT_API_KEY`, or `GEMINI_API_KEY` |
 | Endpoint override | `--responses-url` or `PBI_AGENT_RESPONSES_URL` |
-| Default model | `gemini-3.1-flash-lite-preview` |
+| Default model | `gemini-3.1-pro-preview` |
+| Default sub-model | `gemini-3-flash-preview` |
 | Model override | `--model` or `PBI_AGENT_MODEL` |
 | History mode | Server-side via `previous_interaction_id` |
 | Image input | Supported |
 
 ```bash
 export GEMINI_API_KEY="AIza..."
-uv run pbi-agent --provider google --model gemini-3.1-flash-lite-preview console
+uv run pbi-agent --provider google console
 ```
 
 ## Anthropic
@@ -92,6 +95,7 @@ uv run pbi-agent --provider google --model gemini-3.1-flash-lite-preview console
 | API key | `--api-key`, `PBI_AGENT_API_KEY`, or `ANTHROPIC_API_KEY` |
 | Endpoint override | not currently supported; the provider posts to `https://api.anthropic.com/v1/messages` |
 | Default model | `claude-opus-4-6` |
+| Default sub-model | `claude-sonnet-4-6` |
 | Model override | `--model` or `PBI_AGENT_MODEL` |
 | History mode | Client-side full message replay |
 | Image input | Supported in live sessions; resumed sessions replay only persisted text history |
@@ -109,6 +113,7 @@ uv run pbi-agent --provider anthropic console
 | API key | `--api-key`, `PBI_AGENT_API_KEY`, or `GENERIC_API_KEY` |
 | Endpoint override | `--generic-api-url` or `PBI_AGENT_GENERIC_API_URL` |
 | Default model | none; the request omits `model` when unset |
+| Default sub-model | none; `sub_agent` also omits `model` when unset |
 | Model override | `--model` or `PBI_AGENT_MODEL` |
 | History mode | Client-side full message replay |
 | Image input | Not enabled in this build |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,7 +20,7 @@ If you run `pbi-agent` without a command, the CLI inserts `web` automatically. G
 | `--provider` | `PBI_AGENT_PROVIDER` | `openai` | LLM provider backend: `openai`, `xai`, `google`, `anthropic`, or `generic`. |
 | `--api-key` | `PBI_AGENT_API_KEY` | none | Shared API key override. If unset, provider-specific fallback env vars are checked. |
 | `--model` | `PBI_AGENT_MODEL` | per-provider | Model override for the selected provider. Generic omits `model` when this is unset. |
-| `--sub-agent-model` | `PBI_AGENT_SUB_AGENT_MODEL` | main model | Optional model override for `sub_agent`. When unset, child agents reuse `--model`. |
+| `--sub-agent-model` | `PBI_AGENT_SUB_AGENT_MODEL` | per-provider sub-model | Optional model override for `sub_agent`. When unset, child agents use the provider-specific sub-agent default from `config.py`. |
 | `--max-tokens` | `PBI_AGENT_MAX_TOKENS` | `16384` | Max output tokens for the selected provider. |
 | `--reasoning-effort` | `PBI_AGENT_REASONING_EFFORT` | `xhigh` for OpenAI; `high` otherwise | Requested reasoning effort: `low`, `medium`, `high`, or `xhigh`. |
 | `--max-tool-workers` | `PBI_AGENT_MAX_TOOL_WORKERS` | `4` | Maximum parallel workers for tool execution. |
@@ -33,13 +33,13 @@ If you run `pbi-agent` without a command, the CLI inserts `web` automatically. G
 
 Per-provider model defaults:
 
-| Provider | Default model |
-| --- | --- |
-| OpenAI | `gpt-5.4-2026-03-05` |
-| xAI | `grok-4-1-fast-reasoning` |
-| Google | `gemini-3.1-flash-lite-preview` |
-| Anthropic | `claude-opus-4-6` |
-| Generic | none |
+| Provider | Default model | Default sub-model |
+| --- | --- | --- |
+| OpenAI | `gpt-5.4` | `gpt-5.4-mini` |
+| xAI | `grok-4.20` | `grok-4-1-fast` |
+| Google | `gemini-3.1-pro-preview` | `gemini-3-flash-preview` |
+| Anthropic | `claude-opus-4-6` | `claude-sonnet-4-6` |
+| Generic | none | none |
 
 ## Hidden API-Key Aliases
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -16,7 +16,7 @@ The CLI calls `load_dotenv()` during settings resolution, so a local `.env` file
 | `PBI_AGENT_PROVIDER` | `openai` | Selects the provider backend. |
 | `PBI_AGENT_API_KEY` | none | Shared API key used before provider-specific fallback env vars. |
 | `PBI_AGENT_MODEL` | per-provider | Overrides the provider default model. For Generic, leaving this unset omits `model` from the request body. |
-| `PBI_AGENT_SUB_AGENT_MODEL` | main model | Optional override for the model used by `sub_agent`. When unset, child agents reuse `PBI_AGENT_MODEL`. |
+| `PBI_AGENT_SUB_AGENT_MODEL` | per-provider sub-model | Optional override for the model used by `sub_agent`. When unset, child agents use the provider-specific sub-agent default from `config.py`. |
 | `PBI_AGENT_MAX_TOKENS` | `16384` | Output-token limit applied to the selected provider request body. |
 | `PBI_AGENT_REASONING_EFFORT` | `xhigh` for OpenAI; `high` otherwise | Requested reasoning effort. Providers may map this to provider-specific values internally. |
 | `PBI_AGENT_MAX_TOOL_WORKERS` | `4` | Maximum tool execution workers. |
@@ -45,7 +45,7 @@ These are only consulted when both `--api-key` and `PBI_AGENT_API_KEY` are absen
 ```bash
 PBI_AGENT_PROVIDER=openai
 PBI_AGENT_API_KEY=sk-...
-PBI_AGENT_MODEL=gpt-5.4-2026-03-05
+PBI_AGENT_MODEL=gpt-5.4
 PBI_AGENT_SUB_AGENT_MODEL=gpt-5.4-mini
 PBI_AGENT_MAX_TOOL_WORKERS=4
 PBI_AGENT_MAX_RETRIES=3


### PR DESCRIPTION
### Motivation
- Keep user-facing documentation in sync with the runtime defaults defined in `src/pbi_agent/config.py` for provider main models and provider-specific sub-agent defaults.
- Clarify `sub_agent` behavior so users understand that sub-agents pick a provider-specific default sub-model unless overridden.

### Description
- Updated `docs/guide/providers.md` to add a "Default Sub-Model" column to the provider matrix, update per-provider default model values, and document the provider-specific sub-agent defaults and wording about `sub_agent` behavior.
- Updated `docs/guide/index.md` to include default sub-models alongside default models in the supported-provider matrix.
- Updated `docs/reference/cli.md` and `docs/reference/environment.md` to reflect that `--sub-agent-model` / `PBI_AGENT_SUB_AGENT_MODEL` use provider-specific sub-model defaults and to show the current default model/sub-model table and `.env` example values.
- Alignments are sourced from `src/pbi_agent/config.py` (e.g., OpenAI: `gpt-5.4` / `gpt-5.4-mini`, xAI: `grok-4.20` / `grok-4-1-fast`, Google: `gemini-3.1-pro-preview` / `gemini-3-flash-preview`, Anthropic: `claude-opus-4-6` / `claude-sonnet-4-6`, Generic: none).

### Testing
- `npm run docs:build` completed successfully and produced a site build.
- `uv run ruff check .` passed with no issues.
- `uv run ruff format --check .` passed (files are formatted).
- `uv run pytest` ran the test suite: 351 tests passed and 1 test failed (`tests/test_system_prompt.py::test_permission_error`), which is an environment-sensitive failure unrelated to these documentation edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf139555088330810d98a6dcff39d6)