### PR TITLE
Bump GitHub Actions in tests workflow to checkout@v5 and setup-python@v6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
### Motivation
- Address GitHub’s Node.js 20 deprecation warning and ensure the test workflow uses action releases compatible with the upcoming Node.js 24 runner by updating the actions versions.

### Description
- Update `.github/workflows/tests.yml` to use `actions/checkout@v5` and `actions/setup-python@v6`, replacing the previous `actions/checkout@v4` and `actions/setup-python@v5` entries.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf164cd3dc8330a451c968b0291f7e)