### PR TITLE
fix(mcp): address review issues in MCP integration

### DIFF
--- a/src/pbi_agent/agent/tool_runtime.py
+++ b/src/pbi_agent/agent/tool_runtime.py
@@ -26,11 +26,12 @@ def execute_tool_calls(
     calls: list[ToolCall],
     *,
     max_workers: int,
-    tool_catalog: ToolCatalog | None = None,
     context: ToolContext | None = None,
 ) -> ToolExecutionBatch:
     if not calls:
         return ToolExecutionBatch(results=[], had_errors=False)
+
+    tool_catalog = context.tool_catalog if context is not None else None
 
     if len(calls) == 1 or max_workers == 1:
         results = [

--- a/src/pbi_agent/mcp/pool.py
+++ b/src/pbi_agent/mcp/pool.py
@@ -86,7 +86,11 @@ class McpServerPool:
         if not self._configs:
             return self
         self._start_loop_thread()
-        self._submit(self._connect_all())
+        try:
+            self._submit(self._connect_all())
+        except Exception:
+            self.__exit__(None, None, None)
+            raise
         return self
 
     def __exit__(self, *_: object) -> None:
@@ -94,9 +98,9 @@ class McpServerPool:
             return
         self._submit(self._close_all())
         self._request_queue.put((None, queue.Queue()))
-        self._thread.join(timeout=5.0)
+        self._thread.join(timeout=15.0)
         if self._thread.is_alive():
-            _log.warning("MCP worker thread did not shut down within 5 s")
+            _log.warning("MCP worker thread did not shut down within 15 s")
         self._thread = None
         self._loop = None
 
@@ -191,31 +195,37 @@ class McpServerPool:
             _import_mcp_client_components()
         )
         stack = AsyncExitStack()
-        if config.transport == "http":
-            read_stream, write_stream, _ = await stack.enter_async_context(
-                streamablehttp_client(config.url or "", headers=config.headers or None)
+        try:
+            if config.transport == "http":
+                read_stream, write_stream, _ = await stack.enter_async_context(
+                    streamablehttp_client(
+                        config.url or "", headers=config.headers or None
+                    )
+                )
+            else:
+                env = os.environ.copy()
+                env.update(config.env)
+                server_params = StdioServerParameters(
+                    command=config.command or "",
+                    args=list(config.args),
+                    env=env,
+                    cwd=str(config.cwd) if config.cwd is not None else None,
+                )
+                read_stream, write_stream = await stack.enter_async_context(
+                    stdio_client(server_params)
+                )
+            session = await stack.enter_async_context(
+                ClientSession(read_stream, write_stream)
             )
-        else:
-            env = os.environ.copy()
-            env.update(config.env)
-            server_params = StdioServerParameters(
-                command=config.command or "",
-                args=list(config.args),
-                env=env,
-                cwd=str(config.cwd) if config.cwd is not None else None,
+            await asyncio.wait_for(
+                session.initialize(), timeout=MCP_CONNECT_TIMEOUT_SECONDS
             )
-            read_stream, write_stream = await stack.enter_async_context(
-                stdio_client(server_params)
+            response = await asyncio.wait_for(
+                session.list_tools(), timeout=MCP_CONNECT_TIMEOUT_SECONDS
             )
-        session = await stack.enter_async_context(
-            ClientSession(read_stream, write_stream)
-        )
-        await asyncio.wait_for(
-            session.initialize(), timeout=MCP_CONNECT_TIMEOUT_SECONDS
-        )
-        response = await asyncio.wait_for(
-            session.list_tools(), timeout=MCP_CONNECT_TIMEOUT_SECONDS
-        )
+        except Exception:
+            await stack.aclose()
+            raise
         bindings = _bindings_for_server(config, getattr(response, "tools", []))
         return (
             _ConnectedServer(

--- a/src/pbi_agent/providers/anthropic_provider.py
+++ b/src/pbi_agent/providers/anthropic_provider.py
@@ -213,7 +213,6 @@ class AnthropicProvider(Provider):
         batch = _execute_tool_calls(
             fn_calls,
             max_workers=max_workers,
-            tool_catalog=self._tool_catalog,
             context=ToolContext(
                 settings=self._settings,
                 display=display,

--- a/src/pbi_agent/providers/generic_provider.py
+++ b/src/pbi_agent/providers/generic_provider.py
@@ -134,7 +134,6 @@ class GenericProvider(Provider):
         batch = _execute_tool_calls(
             response.function_calls,
             max_workers=max_workers,
-            tool_catalog=self._tool_catalog,
             context=ToolContext(
                 settings=self._settings,
                 display=display,

--- a/src/pbi_agent/providers/google_provider.py
+++ b/src/pbi_agent/providers/google_provider.py
@@ -186,7 +186,6 @@ class GoogleProvider(Provider):
         batch = _execute_tool_calls(
             response.function_calls,
             max_workers=max_workers,
-            tool_catalog=self._tool_catalog,
             context=ToolContext(
                 settings=self._settings,
                 display=display,

--- a/src/pbi_agent/providers/openai_provider.py
+++ b/src/pbi_agent/providers/openai_provider.py
@@ -176,7 +176,6 @@ class OpenAIProvider(Provider):
         batch = _execute_tool_calls(
             response.function_calls,
             max_workers=max_workers,
-            tool_catalog=self._tool_catalog,
             context=ToolContext(
                 settings=self._settings,
                 display=display,

--- a/src/pbi_agent/providers/xai_provider.py
+++ b/src/pbi_agent/providers/xai_provider.py
@@ -193,7 +193,6 @@ class XAIProvider(Provider):
         batch = _execute_tool_calls(
             response.function_calls,
             max_workers=max_workers,
-            tool_catalog=self._tool_catalog,
             context=ToolContext(
                 settings=self._settings,
                 display=display,

--- a/src/pbi_agent/tools/catalog.py
+++ b/src/pbi_agent/tools/catalog.py
@@ -41,9 +41,10 @@ class ToolCatalog:
         for entry in extra_entries:
             if entry.spec.name in self._entries:
                 _log.warning(
-                    "MCP tool %r shadows a built-in tool with the same name",
+                    "Skipping MCP tool %r: shadows a built-in tool with the same name",
                     entry.spec.name,
                 )
+                continue
             merged[entry.spec.name] = entry
         return ToolCatalog(merged)
 

--- a/tests/test_mcp_pool.py
+++ b/tests/test_mcp_pool.py
@@ -185,6 +185,7 @@ def test_tool_runtime_executes_dynamic_mcp_tool_without_batch_errors(
     )
 
     with McpServerPool(tmp_path) as pool:
+        catalog = pool.to_tool_catalog()
         batch = tool_runtime.execute_tool_calls(
             [
                 ToolCall(
@@ -194,7 +195,7 @@ def test_tool_runtime_executes_dynamic_mcp_tool_without_batch_errors(
                 )
             ],
             max_workers=1,
-            tool_catalog=pool.to_tool_catalog(),
+            context=ToolContext(tool_catalog=catalog),
         )
 
     assert batch.had_errors is False


### PR DESCRIPTION
## Summary
- **Fix subprocess leak** in `_connect_server`: wrap transport/session setup in try/except, close `AsyncExitStack` on failure before re-raising
- **Prevent built-in tool shadowing**: `ToolCatalog.merged()` now skips MCP tools whose names collide with built-in tools instead of silently overwriting them
- **Fix thread leak in `__enter__`**: clean up worker thread if `_connect_all` fails after `_start_loop_thread()`
- **Remove redundant `tool_catalog` parameter**: `execute_tool_calls()` now reads the catalog from `context.tool_catalog` instead of accepting a duplicate standalone kwarg (updated all 5 providers)
- **Increase thread join timeout** from 5s to 15s to accommodate in-flight MCP tool calls during shutdown

## Test plan
- [x] All 420 existing tests pass (`uv run pytest`)
- [x] Lint and format clean (`uv run ruff check .` / `uv run ruff format --check .`)
- [ ] Manual: configure an MCP server in `.agents/mcp.json` and verify tools load and execute
- [ ] Manual: verify an MCP tool with a name matching a built-in (e.g. `read_file`) is skipped with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)