### PR TITLE
Allow web servers in multiple workspaces

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -30,6 +30,7 @@
 
 ## Detailed Task Events
 ## 2026-05-01
+- Added multi-workspace web server startup: CLI now rejects an active same-workspace web lease before binding, auto-selects a free port only for implicit default `8000`, and keeps explicit `--port` strict; SessionStore exposes fresh/stale lease inspection. Validation: targeted Ruff check/format and `uv run pytest tests/test_cli.py tests/test_session_store.py tests/test_web_serve.py -q` passed.
 - Added Kanban task image attachments: backend task upload endpoint + persisted attachments, task create/update image IDs, initial task run image plumbing, frontend TaskModal upload/preview/remove, card image count, docs update. Validation: Ruff check/format targeted, pytest `tests/test_session_store.py` + `tests/test_web_serve.py`, `bun run typecheck`, targeted web tests, `bun run lint`, `bun run web:build`, `bun run docs:build` passed.
 - Ensured existing SQLite DBs add missing `image_attachments_json` on `kanban_tasks` (messages already covered) and added regression coverage for old message/task tables. Validation: `uv run pytest tests/test_session_store.py`, targeted Ruff check/format passed.
 - Fixed review findings for Kanban task images: continuation/stage handoff user messages now persist/publish no task images, and deleting a linked session preserves upload files still owned by tasks. Validation: targeted Ruff check/format and `uv run pytest tests/test_web_serve.py::test_auto_started_stage_prompt_is_visible_while_running tests/test_web_serve.py::test_delete_session_endpoint_preserves_task_owned_uploads -q` passed.

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
-[X] Inspect input mention parser and tests
-[X] Implement safe overlong mention handling
-[X] Add regression tests
+[X] Inspect web startup and lease/storage code
+[X] Implement same-workspace lease preflight and auto-port selection
+[X] Add/update regression tests
 [X] Run targeted validation
 [X] Update memory and summarize

--- a/src/pbi_agent/cli.py
+++ b/src/pbi_agent/cli.py
@@ -65,6 +65,21 @@ WEB_SERVER_BROWSER_WAIT_TIMEOUT_SECONDS = 20.0
 WEB_SERVER_BROWSER_WAIT_RETRY_SECONDS = 10.0
 WEB_SERVER_BROWSER_POLL_INTERVAL_SECONDS = 0.1
 WEB_SERVER_BROWSER_CONNECT_TIMEOUT_SECONDS = 0.2
+WEB_MANAGER_LEASE_STALE_SECONDS = 30.0
+DEFAULT_WEB_PORT = 8000
+
+
+class ExplicitPortAction(argparse.Action):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | int | None,
+        option_string: str | None = None,
+    ) -> None:
+        del parser, option_string
+        setattr(namespace, self.dest, values)
+        setattr(namespace, "_explicit_web_port", True)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -317,9 +332,11 @@ def build_parser() -> argparse.ArgumentParser:
     web_parser.add_argument(
         "--port",
         type=int,
-        default=8000,
+        default=DEFAULT_WEB_PORT,
+        action=ExplicitPortAction,
         help="Port to bind the web server (default: 8000).",
     )
+    web_parser.set_defaults(_explicit_web_port=False)
     web_parser.add_argument(
         "--dev",
         action="store_true",
@@ -1633,6 +1650,20 @@ def _handle_web_command(
         print("Error: --port must be between 1 and 65535.", file=sys.stderr)
         return 2
 
+    try:
+        if _current_workspace_has_active_web_manager():
+            print(
+                "Error: another web app instance is already managing this workspace.",
+                file=sys.stderr,
+            )
+            return 1
+    except Exception as exc:
+        print(f"Error: unable to inspect web server lease: {exc}", file=sys.stderr)
+        return 1
+
+    if not _resolve_web_command_port(args):
+        return 1
+
     browser_url = _browser_target_url(args)
     print(f"Serving web UI on {browser_url}")
     _start_browser_open_thread(args.host, args.port, browser_url)
@@ -1650,6 +1681,66 @@ def _handle_web_command(
     except OSError as exc:
         print(f"Error: failed to launch web server: {exc}", file=sys.stderr)
         return 1
+
+
+def _current_workspace_has_active_web_manager() -> bool:
+    from pbi_agent.session_store import SessionStore
+
+    directory = str(Path.cwd().resolve())
+    with SessionStore() as store:
+        return store.has_active_web_manager_lease(
+            directory,
+            stale_after_seconds=WEB_MANAGER_LEASE_STALE_SECONDS,
+        )
+
+
+def _resolve_web_command_port(args: argparse.Namespace) -> bool:
+    if getattr(args, "_explicit_web_port", False):
+        return True
+    if args.port != DEFAULT_WEB_PORT:
+        return True
+    if _is_web_port_available(args.host, args.port):
+        return True
+
+    free_port = _find_free_web_port(args.host)
+    if free_port is None:
+        print("Error: unable to find a free port for the web server.", file=sys.stderr)
+        return False
+
+    print(
+        f"Port {DEFAULT_WEB_PORT} is unavailable; using port {free_port}.",
+        file=sys.stderr,
+    )
+    args.port = free_port
+    return True
+
+
+def _is_web_port_available(host: str, port: int) -> bool:
+    try:
+        with _bind_web_port_probe(host, port):
+            return True
+    except OSError:
+        return False
+
+
+def _find_free_web_port(host: str) -> int | None:
+    try:
+        with _bind_web_port_probe(host, 0) as probe:
+            return int(probe.getsockname()[1])
+    except OSError:
+        return None
+
+
+@contextlib.contextmanager
+def _bind_web_port_probe(host: str, port: int):
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    sock = socket.socket(family, socket.SOCK_STREAM)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+        yield sock
+    finally:
+        sock.close()
 
 
 def _browser_target_url(args: argparse.Namespace) -> str:

--- a/src/pbi_agent/session_store.py
+++ b/src/pbi_agent/session_store.py
@@ -709,6 +709,25 @@ class SessionStore:
                     self._conn.rollback()
                 raise
 
+    def has_active_web_manager_lease(
+        self,
+        directory: str,
+        *,
+        stale_after_seconds: float,
+    ) -> bool:
+        normalized_directory = _normalize_directory_key(directory)
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT heartbeat_at FROM web_manager_leases WHERE directory = ?",
+                (normalized_directory,),
+            ).fetchone()
+        if row is None:
+            return False
+        return not _is_stale_timestamp(
+            str(row["heartbeat_at"]),
+            stale_after_seconds=stale_after_seconds,
+        )
+
     def renew_web_manager_lease(self, directory: str, *, owner_id: str) -> bool:
         normalized_directory = _normalize_directory_key(directory)
         now = _now_iso()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -451,6 +451,10 @@ class DefaultWebCommandTests(unittest.TestCase):
         server = Mock()
 
         with (
+            patch(
+                "pbi_agent.cli._current_workspace_has_active_web_manager",
+                return_value=False,
+            ),
             patch("pbi_agent.cli._start_browser_open_thread") as mock_browser_thread,
             patch(
                 "pbi_agent.cli._create_web_server", return_value=server
@@ -470,6 +474,124 @@ class DefaultWebCommandTests(unittest.TestCase):
         self.assertEqual(runtime.provider_id, "")
         self.assertEqual(runtime.profile_id, "")
         server.serve.assert_called_once_with(debug=False)
+
+    def test_handle_web_command_uses_default_port_when_available(self) -> None:
+        parser = cli.build_parser()
+        args = parser.parse_args(["web"])
+        settings = self._settings()
+        server = Mock()
+
+        with (
+            patch(
+                "pbi_agent.cli._current_workspace_has_active_web_manager",
+                return_value=False,
+            ),
+            patch(
+                "pbi_agent.cli._is_web_port_available", return_value=True
+            ) as mock_available,
+            patch("pbi_agent.cli._find_free_web_port") as mock_find_port,
+            patch("pbi_agent.cli._start_browser_open_thread") as mock_browser_thread,
+            patch(
+                "pbi_agent.cli._create_web_server", return_value=server
+            ) as mock_server,
+        ):
+            rc = cli._handle_web_command(args, settings)
+
+        self.assertEqual(rc, 0)
+        mock_available.assert_called_once_with("127.0.0.1", 8000)
+        mock_find_port.assert_not_called()
+        mock_browser_thread.assert_called_once_with(
+            "127.0.0.1",
+            8000,
+            "http://127.0.0.1:8000",
+        )
+        self.assertEqual(mock_server.call_args.args[0].port, 8000)
+
+    def test_handle_web_command_auto_selects_free_default_port(self) -> None:
+        parser = cli.build_parser()
+        args = parser.parse_args(["web"])
+        settings = self._settings()
+        server = Mock()
+        stderr = io.StringIO()
+
+        with (
+            patch("sys.stderr", stderr),
+            patch(
+                "pbi_agent.cli._current_workspace_has_active_web_manager",
+                return_value=False,
+            ),
+            patch("pbi_agent.cli._is_web_port_available", return_value=False),
+            patch("pbi_agent.cli._find_free_web_port", return_value=8123),
+            patch("pbi_agent.cli._start_browser_open_thread") as mock_browser_thread,
+            patch(
+                "pbi_agent.cli._create_web_server", return_value=server
+            ) as mock_server,
+        ):
+            rc = cli._handle_web_command(args, settings)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(args.port, 8123)
+        self.assertIn("Port 8000 is unavailable; using port 8123", stderr.getvalue())
+        mock_browser_thread.assert_called_once_with(
+            "127.0.0.1",
+            8123,
+            "http://127.0.0.1:8123",
+        )
+        self.assertEqual(mock_server.call_args.args[0].port, 8123)
+
+    def test_handle_web_command_explicit_port_does_not_auto_select(self) -> None:
+        parser = cli.build_parser()
+        args = parser.parse_args(["web", "--port", "8000"])
+        settings = self._settings()
+        server = Mock()
+
+        with (
+            patch(
+                "pbi_agent.cli._current_workspace_has_active_web_manager",
+                return_value=False,
+            ),
+            patch("pbi_agent.cli._is_web_port_available") as mock_available,
+            patch("pbi_agent.cli._find_free_web_port") as mock_find_port,
+            patch("pbi_agent.cli._start_browser_open_thread") as mock_browser_thread,
+            patch(
+                "pbi_agent.cli._create_web_server", return_value=server
+            ) as mock_server,
+        ):
+            rc = cli._handle_web_command(args, settings)
+
+        self.assertEqual(rc, 0)
+        mock_available.assert_not_called()
+        mock_find_port.assert_not_called()
+        mock_browser_thread.assert_called_once_with(
+            "127.0.0.1",
+            8000,
+            "http://127.0.0.1:8000",
+        )
+        self.assertEqual(mock_server.call_args.args[0].port, 8000)
+
+    def test_handle_web_command_rejects_active_same_workspace_lease(self) -> None:
+        parser = cli.build_parser()
+        args = parser.parse_args(["web"])
+        settings = self._settings()
+        stderr = io.StringIO()
+
+        with (
+            patch("sys.stderr", stderr),
+            patch(
+                "pbi_agent.cli._current_workspace_has_active_web_manager",
+                return_value=True,
+            ),
+            patch("pbi_agent.cli._is_web_port_available") as mock_available,
+            patch("pbi_agent.cli._start_browser_open_thread") as mock_browser_thread,
+            patch("pbi_agent.cli._create_web_server") as mock_server,
+        ):
+            rc = cli._handle_web_command(args, settings)
+
+        self.assertEqual(rc, 1)
+        self.assertIn("already managing this workspace", stderr.getvalue())
+        mock_available.assert_not_called()
+        mock_browser_thread.assert_not_called()
+        mock_server.assert_not_called()
 
     def test_handle_web_command_sets_and_restores_settings_env(self) -> None:
         parser = cli.build_parser()
@@ -492,6 +614,10 @@ class DefaultWebCommandTests(unittest.TestCase):
 
         try:
             with (
+                patch(
+                    "pbi_agent.cli._current_workspace_has_active_web_manager",
+                    return_value=False,
+                ),
                 patch("pbi_agent.cli._start_browser_open_thread"),
                 patch("pbi_agent.cli._create_web_server", return_value=server),
             ):
@@ -766,6 +892,10 @@ class DefaultWebCommandTests(unittest.TestCase):
         server.serve.side_effect = KeyboardInterrupt()
 
         with (
+            patch(
+                "pbi_agent.cli._current_workspace_has_active_web_manager",
+                return_value=False,
+            ),
             patch("pbi_agent.cli._start_browser_open_thread"),
             patch("pbi_agent.cli._create_web_server", return_value=server),
         ):

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -548,6 +548,64 @@ def test_web_manager_lease_blocks_concurrent_owner(tmp_path) -> None:
         )
 
 
+def test_has_active_web_manager_lease_detects_fresh_lease(tmp_path) -> None:
+    db = tmp_path / "sessions.db"
+    with SessionStore(db_path=db) as store:
+        assert not store.has_active_web_manager_lease(
+            "/w",
+            stale_after_seconds=30,
+        )
+        assert store.acquire_web_manager_lease(
+            "/w",
+            owner_id="owner-a",
+            stale_after_seconds=30,
+        )
+        assert store.has_active_web_manager_lease(
+            "/W",
+            stale_after_seconds=30,
+        )
+
+
+def test_has_active_web_manager_lease_ignores_released_lease(tmp_path) -> None:
+    db = tmp_path / "sessions.db"
+    with SessionStore(db_path=db) as store:
+        assert store.acquire_web_manager_lease(
+            "/w",
+            owner_id="owner-a",
+            stale_after_seconds=30,
+        )
+        assert store.release_web_manager_lease("/w", owner_id="owner-a")
+        assert not store.has_active_web_manager_lease(
+            "/w",
+            stale_after_seconds=30,
+        )
+
+
+def test_has_active_web_manager_lease_ignores_stale_lease(tmp_path) -> None:
+    db = tmp_path / "sessions.db"
+    with SessionStore(db_path=db) as store:
+        assert store.acquire_web_manager_lease(
+            "/w",
+            owner_id="owner-a",
+            stale_after_seconds=30,
+        )
+        with store._lock:
+            store._conn.execute(
+                "UPDATE web_manager_leases SET heartbeat_at = ?, updated_at = ? "
+                "WHERE directory = ?",
+                (
+                    "2000-01-01T00:00:00+00:00",
+                    "2000-01-01T00:00:00+00:00",
+                    "/w",
+                ),
+            )
+            store._conn.commit()
+        assert not store.has_active_web_manager_lease(
+            "/w",
+            stale_after_seconds=30,
+        )
+
+
 def test_web_manager_lease_atomic_across_concurrent_startup(tmp_path) -> None:
     db = tmp_path / "sessions.db"
     with SessionStore(db_path=db):


### PR DESCRIPTION
## Summary
- keep same-workspace web manager lease enforcement before startup
- auto-select a free port when implicit default 8000 is unavailable
- add session-store lease inspection and CLI/session-store regression coverage

## Local validation
- `uv run ruff check .` passed
- `uv run ruff format .` passed, 151 files unchanged
- `uv run pytest` passed, 777 tests
- `bun run test:web` passed, 131 tests
- `bun run lint` passed
- `bun run typecheck` passed
- `bun run web:build` passed

## GitHub workflow checks
- Pending: will run `gh pr checks <pr> --watch --fail-fast --interval 10` before merge

## Known unshipped or skipped changes
- None