### PR TITLE
Add visible session spinner color transitions

### DIFF
--- a/webapp/src/components/session/SessionTimeline.test.tsx
+++ b/webapp/src/components/session/SessionTimeline.test.tsx
@@ -935,6 +935,239 @@ describe("SessionTimeline", () => {
     expect(screen.getByLabelText("running")).toBeInTheDocument();
   });
 
+  it("delays active Working phase color changes without replacing the spinner", () => {
+    vi.useFakeTimers();
+    const items = [
+      {
+        kind: "thinking" as const,
+        itemId: "thinking-1",
+        title: "Thinking",
+        content: "Planning",
+      },
+    ];
+    const { rerender } = render(
+      <SessionTimeline
+        items={items}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "model_wait", message: "Analyzing..." }}
+        itemsVersion={1}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /Working/ });
+    const spinner = screen.getByLabelText("running");
+    expect(trigger).toHaveAttribute("data-phase", "model_wait");
+
+    rerender(
+      <SessionTimeline
+        items={items}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "tool_execution", message: "Running shell..." }}
+        itemsVersion={2}
+      />,
+    );
+
+    expect(trigger).toHaveAttribute("data-phase", "model_wait");
+    expect(screen.getByLabelText("running")).toBe(spinner);
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(trigger).toHaveAttribute("data-phase", "tool_execution");
+    expect(screen.getByLabelText("running")).toBe(spinner);
+  });
+
+  it("keeps the active Working spinner stable and delays color changes when the first tool run replaces the placeholder", () => {
+    vi.useFakeTimers();
+    const initialItems = [
+      {
+        kind: "message" as const,
+        itemId: "user-1",
+        role: "user" as const,
+        content: "Do the task",
+        markdown: false,
+      },
+    ];
+    const toolItems = [
+      ...initialItems,
+      {
+        kind: "tool_group" as const,
+        itemId: "tool-1",
+        label: "shell",
+        status: "running" as const,
+        items: [
+          {
+            text: "Running command",
+            metadata: {
+              tool_name: "shell" as const,
+              command: "echo ok",
+            },
+          },
+        ],
+      },
+    ];
+    const { rerender } = render(
+      <SessionTimeline
+        items={initialItems}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "model_wait", message: "Analyzing..." }}
+        itemsVersion={1}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /Working/ });
+    const spinner = screen.getByLabelText("running");
+    expect(trigger).toHaveAttribute("data-phase", "model_wait");
+
+    rerender(
+      <SessionTimeline
+        items={toolItems}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "tool_execution", message: "Running shell..." }}
+        itemsVersion={2}
+      />,
+    );
+
+    expect(trigger).toHaveAttribute("data-phase", "model_wait");
+    expect(screen.getByLabelText("running")).toBe(spinner);
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(trigger).toHaveAttribute("data-phase", "tool_execution");
+    expect(screen.getByLabelText("running")).toBe(spinner);
+  });
+
+  it("clears stale queued active Working phases when the current phase returns to the visible color", () => {
+    vi.useFakeTimers();
+    const items = [
+      {
+        kind: "thinking" as const,
+        itemId: "thinking-1",
+        title: "Thinking",
+        content: "Planning",
+      },
+    ];
+    const { rerender } = render(
+      <SessionTimeline
+        items={items}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "model_wait", message: "Analyzing..." }}
+        itemsVersion={1}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /Working/ });
+    expect(trigger).toHaveAttribute("data-phase", "model_wait");
+
+    rerender(
+      <SessionTimeline
+        items={items}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "tool_execution", message: "Running shell..." }}
+        itemsVersion={2}
+      />,
+    );
+    rerender(
+      <SessionTimeline
+        items={items}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "model_wait", message: "Analyzing..." }}
+        itemsVersion={3}
+      />,
+    );
+
+    expect(trigger).toHaveAttribute("data-phase", "model_wait");
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(trigger).toHaveAttribute("data-phase", "model_wait");
+  });
+
+  it("shows each queued active Working phase for a visible interval", () => {
+    vi.useFakeTimers();
+    const items = [
+      {
+        kind: "thinking" as const,
+        itemId: "thinking-1",
+        title: "Thinking",
+        content: "Planning",
+      },
+    ];
+    const { rerender } = render(
+      <SessionTimeline
+        items={items}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "model_wait", message: "Analyzing..." }}
+        itemsVersion={1}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /Working/ });
+    expect(trigger).toHaveAttribute("data-phase", "model_wait");
+
+    rerender(
+      <SessionTimeline
+        items={items}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "tool_execution", message: "Running shell..." }}
+        itemsVersion={2}
+      />,
+    );
+    rerender(
+      <SessionTimeline
+        items={items}
+        subAgents={{}}
+        connection="connected"
+        waitMessage={null}
+        processing={{ active: true, phase: "finalizing", message: "Finalizing..." }}
+        itemsVersion={3}
+      />,
+    );
+
+    expect(trigger).toHaveAttribute("data-phase", "model_wait");
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(trigger).toHaveAttribute("data-phase", "tool_execution");
+
+    act(() => {
+      vi.advanceTimersByTime(899);
+    });
+
+    expect(trigger).toHaveAttribute("data-phase", "tool_execution");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(trigger).toHaveAttribute("data-phase", "finalizing");
+  });
+
   it("renders a synthetic Working header when the latest item is a user message and the session is active", () => {
     render(
       <SessionTimeline

--- a/webapp/src/components/session/SessionTimeline.tsx
+++ b/webapp/src/components/session/SessionTimeline.tsx
@@ -20,6 +20,10 @@ import { SessionWelcome } from "./SessionWelcome";
 
 const USER_MESSAGE_TOP_OFFSET = 8;
 const ASSISTANT_MESSAGE_TOP_OFFSET = 8;
+const WORK_RUN_PHASE_MIN_VISIBLE_MS = 600;
+const WORK_RUN_PHASE_TRANSITION_MS = 300;
+const WORK_RUN_PHASE_HOLD_MS =
+  WORK_RUN_PHASE_MIN_VISIBLE_MS + WORK_RUN_PHASE_TRANSITION_MS;
 
 type WorkItem = TimelineThinkingItem | TimelineToolGroupItem;
 
@@ -41,6 +45,8 @@ function buildRenderUnits(items: TimelineItem[]): RenderUnit[] {
   const units: RenderUnit[] = [];
   let buffer: WorkItem[] = [];
   let bufferSubAgent: string | undefined;
+  let previousMessageItemId: string | undefined;
+  let workRunSinceMessage = false;
 
   const flush = () => {
     if (buffer.length === 0) return;
@@ -49,19 +55,25 @@ function buildRenderUnits(items: TimelineItem[]): RenderUnit[] {
     );
     units.push({
       kind: "work_run",
-      key: `work-${buffer[0].itemId}`,
+      key:
+        previousMessageItemId && !workRunSinceMessage
+          ? `work-after-${previousMessageItemId}`
+          : `work-${buffer[0].itemId}`,
       items: buffer,
       subAgentId: bufferSubAgent,
       running,
     });
     buffer = [];
     bufferSubAgent = undefined;
+    workRunSinceMessage = true;
   };
 
   for (const item of items) {
     if (!isWorkItem(item)) {
       flush();
       units.push({ kind: "message", item });
+      previousMessageItemId = item.itemId;
+      workRunSinceMessage = false;
       continue;
     }
     if (buffer.length > 0 && bufferSubAgent !== item.subAgentId) {
@@ -97,6 +109,108 @@ function waitForImages(container: HTMLElement): Promise<void> {
 }
 
 type WorkRunPhase = ProcessingPhase | "active";
+
+function useVisibleWorkRunPhase(phase: WorkRunPhase | null) {
+  const [visiblePhase, setVisiblePhase] = useState(phase);
+  const visiblePhaseRef = useRef(phase);
+  const visibleSinceRef = useRef(0);
+  const queuedPhasesRef = useRef<WorkRunPhase[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current === null) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const markVisiblePhase = useCallback((nextPhase: WorkRunPhase | null) => {
+    visiblePhaseRef.current = nextPhase;
+    visibleSinceRef.current = Date.now();
+  }, []);
+
+  const setVisiblePhaseNow = useCallback(
+    (nextPhase: WorkRunPhase | null) => {
+      markVisiblePhase(nextPhase);
+      setVisiblePhase(nextPhase);
+    },
+    [markVisiblePhase],
+  );
+
+  const scheduleNextPhase = useCallback(
+    function scheduleQueuedPhase() {
+      if (timerRef.current !== null || queuedPhasesRef.current.length === 0) {
+        return;
+      }
+
+      const elapsed = Date.now() - visibleSinceRef.current;
+      const delay = Math.max(WORK_RUN_PHASE_HOLD_MS - elapsed, 0);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        const nextPhase = queuedPhasesRef.current.shift();
+        if (!nextPhase) return;
+        setVisiblePhaseNow(nextPhase);
+        scheduleQueuedPhase();
+      }, delay);
+    },
+    [setVisiblePhaseNow],
+  );
+
+  useEffect(() => {
+    if (visiblePhaseRef.current !== null && visibleSinceRef.current === 0) {
+      visibleSinceRef.current = Date.now();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (phase === null) {
+      queuedPhasesRef.current = [];
+      clearTimer();
+      if (visiblePhaseRef.current !== null) {
+        markVisiblePhase(null);
+        setTimeout(() => {
+          setVisiblePhase(null);
+        }, 0);
+      }
+      return;
+    }
+
+    if (visiblePhaseRef.current === null) {
+      markVisiblePhase(phase);
+      setTimeout(() => {
+        setVisiblePhase(phase);
+      }, 0);
+      return;
+    }
+
+    if (phase === visiblePhaseRef.current) {
+      queuedPhasesRef.current = [];
+      clearTimer();
+      return;
+    }
+
+    const queuedPhaseIndex = queuedPhasesRef.current.indexOf(phase);
+    if (queuedPhaseIndex !== -1) {
+      queuedPhasesRef.current = queuedPhasesRef.current.slice(
+        0,
+        queuedPhaseIndex + 1,
+      );
+      scheduleNextPhase();
+      return;
+    }
+
+    queuedPhasesRef.current.push(phase);
+    scheduleNextPhase();
+  }, [clearTimer, markVisiblePhase, phase, scheduleNextPhase]);
+
+  useEffect(
+    () => () => {
+      clearTimer();
+    },
+    [clearTimer],
+  );
+
+  return visiblePhase;
+}
 
 function WorkRun({
   unit,
@@ -197,6 +311,7 @@ export function SessionTimeline({
   const activePhase: WorkRunPhase | null = sessionIsActive
     ? processing?.phase ?? "active"
     : null;
+  const visibleActivePhase = useVisibleWorkRunPhase(activePhase);
   const renderUnits = useMemo(() => {
     if (!sessionIsActive) return baseRenderUnits;
     const last = baseRenderUnits[baseRenderUnits.length - 1];
@@ -205,13 +320,15 @@ export function SessionTimeline({
       ...baseRenderUnits,
       {
         kind: "work_run" as const,
-        key: "work-active-placeholder",
+        key: latestItem?.kind === "message"
+          ? `work-after-${latestItem.itemId}`
+          : "work-active-placeholder",
         items: [],
         subAgentId: undefined,
         running: true,
       },
     ];
-  }, [baseRenderUnits, sessionIsActive]);
+  }, [baseRenderUnits, latestItem, sessionIsActive]);
   const latestRenderUnit = renderUnits[renderUnits.length - 1];
   const activeWorkRunKey =
     sessionIsActive && latestRenderUnit?.kind === "work_run"
@@ -383,7 +500,7 @@ export function SessionTimeline({
               unit={unit}
               subAgents={subAgents}
               active={isActiveUnit}
-              phase={isActiveUnit ? activePhase : null}
+              phase={isActiveUnit ? visibleActivePhase : null}
               closeSignal={closeCollapsiblesSignal}
               onUserOpen={
                 isActiveRunningUnit ? handleUserOpenCollapsible : undefined

--- a/webapp/src/styles/session.css
+++ b/webapp/src/styles/session.css
@@ -865,6 +865,7 @@
   border-radius: var(--radius-pill);
   animation: spin 0.8s linear infinite;
   margin-left: auto;
+  transition: border-color var(--duration-normal) var(--ease-out);
 }
 
 .timeline-entry--tool .timeline-entry__body {
@@ -892,7 +893,10 @@
   color: var(--color-muted-foreground);
   cursor: pointer;
   user-select: none;
-  transition: background var(--duration-fast);
+  transition:
+    background var(--duration-fast),
+    border-left-color var(--duration-normal) var(--ease-out),
+    color var(--duration-normal) var(--ease-out);
 }
 
 .timeline-entry__header--work-run:hover {


### PR DESCRIPTION
## Summary
- Smoothly transition active session Working header/spinner colors.
- Keep the Working spinner DOM node stable from placeholder to first tool run.
- Queue rapid phase color changes so each color remains visible and stale queued phases are cleared.

## Local validation
- bun run test:web -- SessionTimeline: passed
- bun run lint: passed
- bun run typecheck: passed
- bun run web:build: passed
- uv run ruff check .: passed
- uv run ruff format .: passed
- bun run test:web: passed
- env -u PBI_AGENT_REASONING_EFFORT uv run pytest: passed (787 passed)
- uv run ruff format --check .: passed

Note: raw uv run pytest failed only because the local environment exports PBI_AGENT_REASONING_EFFORT=low, overriding provider default expectations in two unrelated tests; rerunning without that env var passed.

## GitHub workflow checks
- Pending; will verify with gh pr checks before merge.

## Known unshipped/skipped changes
- Left unrelated/workflow dirty files unstaged: MEMORY.md, TODO.md, .agents/commands/plan-interactive.md, and generated static app bundle changes from local build.