### PR TITLE
Add dead code validation script

### DIFF
--- a/.agents/commands/release.md
+++ b/.agents/commands/release.md
@@ -81,6 +81,7 @@ When user asks to continue, merge, or publish existing release workflow:
 11. Validate:
    - `uv run ruff check .`
    - `uv run ruff format --check .`
+   - `uv run python scripts/dead_code.py`
    - `uv run pytest`
    - `bun run docs:build`
 12. Stage only release-scoped paths and inspect `git diff --cached`.

--- a/.agents/commands/ship-task.md
+++ b/.agents/commands/ship-task.md
@@ -48,7 +48,7 @@ Stop without shipping if:
 1. Start with `git status --short --branch` and inspect the diff before making Git changes.
 2. Identify current task scope from diff and available session context. Prefer explicit file paths when staging.
 3. Run focused validation for the touched surfaces before committing, then verify the full Python and web test suites pass before shipping:
-   - Python: `uv run ruff check .`, `uv run ruff format .` and full `uv run pytest`.
+   - Python: `uv run ruff check .`, `uv run ruff format .`, `uv run python scripts/dead_code.py`, and full `uv run pytest`.
    - Frontend: `bun run test:web`, `bun run lint`, `bun run typecheck`, and `bun run web:build`.
    - Docs: `bun run docs:build`.
    - Broad changes: run repo-level checks from project instructions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,5 @@ dev = [
     "pytest==9.0.3",
     "pytest-asyncio>=1.3.0",
     "ruff==0.15.7",
+    "vulture==2.16",
 ]

--- a/scripts/dead_code.py
+++ b/scripts/dead_code.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Run Vulture dead-code detection with a repo-friendly summary.
+
+This wrapper is intentionally advisory by default: Vulture exits with status 3
+when it finds unused code, but this script returns success unless
+``--fail-on-findings`` is set. That makes it useful for first-pass evaluation
+without breaking local workflows or CI before a whitelist is established.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_PATHS = ("src/pbi_agent", "tests")
+DEFAULT_MIN_CONFIDENCE = 100
+FINDING_RE = re.compile(
+    r"^(?P<path>.*?):(?P<line>\d+): (?P<message>.*?) "
+    r"\((?P<confidence>\d+)% confidence, (?P<size>\d+) lines?\)$"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    message: str
+    confidence: int
+    size: int
+
+    @property
+    def kind(self) -> str:
+        if self.message.startswith("unused "):
+            return " ".join(self.message.split(" ", 2)[:2])
+        if self.message.startswith("unreachable code"):
+            return "unreachable code"
+        return self.message.split(" ", 1)[0]
+
+
+def parse_finding(line: str) -> Finding | None:
+    match = FINDING_RE.match(line)
+    if not match:
+        return None
+    return Finding(
+        path=match.group("path"),
+        line=int(match.group("line")),
+        message=match.group("message"),
+        confidence=int(match.group("confidence")),
+        size=int(match.group("size")),
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Vulture against the Python backend and summarize likely dead code.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=list(DEFAULT_PATHS),
+        help=f"Files/directories to scan (default: {' '.join(DEFAULT_PATHS)}).",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=int,
+        default=DEFAULT_MIN_CONFIDENCE,
+        help=f"Minimum Vulture confidence to report (default: {DEFAULT_MIN_CONFIDENCE}).",
+    )
+    parser.add_argument(
+        "--exclude",
+        default=None,
+        help="Comma-separated Vulture exclude patterns.",
+    )
+    parser.add_argument(
+        "--ignore-decorators",
+        default=None,
+        help="Comma-separated Vulture decorator ignore patterns, e.g. @router.get,@pytest.fixture.",
+    )
+    parser.add_argument(
+        "--ignore-names",
+        default=None,
+        help="Comma-separated Vulture name ignore patterns.",
+    )
+    parser.add_argument(
+        "--no-sort-by-size",
+        action="store_true",
+        help="Do not ask Vulture to sort unused functions/classes by size.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Print Vulture's raw output after the summary.",
+    )
+    parser.add_argument(
+        "--fail-on-findings",
+        action="store_true",
+        help="Exit non-zero when Vulture reports findings.",
+    )
+    return parser.parse_args(argv)
+
+
+def build_vulture_command(args: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "vulture",
+        *args.paths,
+        "--min-confidence",
+        str(args.min_confidence),
+    ]
+    if not args.no_sort_by_size:
+        command.append("--sort-by-size")
+    if args.exclude:
+        command.extend(("--exclude", args.exclude))
+    if args.ignore_decorators:
+        command.extend(("--ignore-decorators", args.ignore_decorators))
+    if args.ignore_names:
+        command.extend(("--ignore-names", args.ignore_names))
+    return command
+
+
+def summarize(findings: list[Finding], raw_lines: list[str]) -> str:
+    if not findings and not raw_lines:
+        return "No dead-code findings reported by Vulture."
+
+    lines = ["Dead-code findings from Vulture", ""]
+    if findings:
+        total_size = sum(finding.size for finding in findings)
+        lines.append(f"Total: {len(findings)} findings, {total_size} reported lines")
+        lines.append("")
+
+        by_confidence = Counter(finding.confidence for finding in findings)
+        confidence_bits = ", ".join(
+            f"{confidence}%: {count}"
+            for confidence, count in sorted(by_confidence.items(), reverse=True)
+        )
+        lines.append(f"By confidence: {confidence_bits}")
+
+        by_kind = Counter(finding.kind for finding in findings)
+        lines.append("By kind:")
+        for kind, count in by_kind.most_common():
+            lines.append(f"  - {kind}: {count}")
+        lines.append("")
+
+        by_path: dict[str, list[Finding]] = defaultdict(list)
+        for finding in findings:
+            by_path[finding.path].append(finding)
+        lines.append("By file:")
+        for path, file_findings in sorted(by_path.items()):
+            file_size = sum(finding.size for finding in file_findings)
+            lines.append(
+                f"  - {path}: {len(file_findings)} findings, {file_size} lines"
+            )
+        lines.append("")
+
+        lines.append("Findings:")
+        for finding in findings:
+            lines.append(
+                f"  - {finding.path}:{finding.line}: {finding.message} "
+                f"({finding.confidence}% confidence, {finding.size} lines)"
+            )
+    else:
+        lines.append(
+            "Vulture produced output, but this wrapper could not parse it as findings."
+        )
+
+    if raw_lines:
+        lines.append("")
+        lines.append("Raw Vulture output:")
+        lines.extend(f"  {line}" for line in raw_lines)
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    missing_paths = [path for path in args.paths if not Path(path).exists()]
+    if missing_paths:
+        print(
+            f"error: scan path does not exist: {', '.join(missing_paths)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    command = build_vulture_command(args)
+    completed = subprocess.run(  # noqa: S603 - command is built from sys.executable plus local args.
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    if completed.stderr:
+        print(completed.stderr, file=sys.stderr, end="")
+
+    raw_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    findings = [
+        finding for line in raw_lines if (finding := parse_finding(line)) is not None
+    ]
+    print(summarize(findings, raw_lines if args.raw else []))
+
+    if completed.returncode not in (0, 3):
+        return completed.returncode
+    if findings and args.fail_on_findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pbi_agent/providers/google_provider.py
+++ b/src/pbi_agent/providers/google_provider.py
@@ -687,7 +687,6 @@ def _extract_google_text_annotation_sources(
                 )
             )
     return sources
-    return sources
 
 
 def _extract_google_grounding_metadata(

--- a/src/pbi_agent/providers/openai_provider.py
+++ b/src/pbi_agent/providers/openai_provider.py
@@ -1472,7 +1472,6 @@ def _merge_sse_indexed_list(existing: list[Any], new_values: list[Any]) -> list[
         elif not merged[index]:
             merged[index] = value
     return merged
-    return merged
 
 
 def _append_sse_message_delta(

--- a/tests/test_project_agents.py
+++ b/tests/test_project_agents.py
@@ -354,6 +354,7 @@ def test_private_repo_404_falls_back_to_git_and_succeeds(
         timeout: int,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        assert check is False
         git_calls.append(
             (tuple(args), None if env is None else env.get("GIT_TERMINAL_PROMPT"))
         )

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -342,6 +342,7 @@ def test_private_repo_404_falls_back_to_git_and_succeeds(
         timeout: int,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        assert check is False
         git_calls.append(
             (tuple(args), None if env is None else env.get("GIT_TERMINAL_PROMPT"))
         )

--- a/tests/test_project_skills.py
+++ b/tests/test_project_skills.py
@@ -330,6 +330,7 @@ def test_private_repo_404_falls_back_to_git_and_succeeds(
         timeout: int,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        assert check is False
         git_calls.append(
             (tuple(args), None if env is None else env.get("GIT_TERMINAL_PROMPT"))
         )
@@ -411,6 +412,7 @@ def test_tree_url_with_slashful_ref_works_via_git_fallback(
         timeout: int,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        assert check is False
         git_calls.append(tuple(args))
         if args[:3] == ["gh", "auth", "token"]:
             return subprocess.CompletedProcess(args, 1, "", "no auth")
@@ -467,6 +469,7 @@ def test_https_auth_failure_retries_ssh_before_surfacing_final_error(
         timeout: int,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        assert check is False
         if args[:3] == ["gh", "auth", "token"]:
             return subprocess.CompletedProcess(args, 1, "", "no auth")
         if args[:3] == ["git", "clone", "--depth"]:
@@ -556,6 +559,7 @@ def test_temp_materialization_is_removed_after_archive_parse_failure(
         timeout: int,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        assert check is False
         if args[:3] == ["gh", "auth", "token"]:
             return subprocess.CompletedProcess(args, 1, "", "no auth")
         if args[:3] == ["git", "clone", "--depth"]:
@@ -592,6 +596,7 @@ def test_temp_materialization_is_removed_after_clone_failure(
         timeout: int,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        assert check is False
         if args[:3] == ["gh", "auth", "token"]:
             return subprocess.CompletedProcess(args, 1, "", "no auth")
         if args[:3] == ["git", "clone", "--depth"]:

--- a/uv.lock
+++ b/uv.lock
@@ -941,6 +941,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -963,6 +964,7 @@ dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = "==0.15.7" },
+    { name = "vulture", specifier = "==2.16" },
 ]
 
 [[package]]
@@ -1717,6 +1719,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `scripts/dead_code.py`, an advisory Vulture wrapper for backend dead-code scanning.
- Add Vulture as a dev dependency and include the dead-code script in ship/release validation instructions.
- Remove duplicate unreachable provider returns and make test subprocess fakes explicitly use `check`.

## Local validation
- `uv run ruff check .` passed.
- `uv run ruff format .` passed; 153 files left unchanged.
- `uv run python scripts/dead_code.py` passed with no findings.
- `uv run pytest` passed; 791 tests.
- `bun run test:web` passed; 206 tests.
- `bun run lint` passed.
- `bun run typecheck` passed.
- `bun run web:build` passed.
- `bun run docs:build` passed.

## GitHub workflow checks
- Pending: will run `gh pr checks <pr> --watch --fail-fast --interval 10` before merge.

## Known unshipped or skipped changes
- Existing local changes in `AGENTS.md`, `MEMORY.md`, and `TODO.md` were not staged or shipped.