### PR TITLE
chore: release v0.2.0

### DIFF
--- a/docs/changelog/v0.2.0.md
+++ b/docs/changelog/v0.2.0.md
@@ -9,23 +9,27 @@ description: Changelog for pbi-agent v0.2.0, released on 2026-05-05.
 
 ## Added
 
-- Added durable SSE replay and recovery so web sessions can reconnect without losing timeline progress ([4e4f70d](https://github.com/pbi-agent/pbi-agent/commit/4e4f70d), [713f50a](https://github.com/pbi-agent/pbi-agent/commit/713f50a)).
-- Added saved-session timeline, profile, ask-user, and image handling improvements for more complete session review and continuation ([672eca1](https://github.com/pbi-agent/pbi-agent/commit/672eca1), [d4028df](https://github.com/pbi-agent/pbi-agent/commit/d4028df)).
-- Added packaging coverage for the built web static bundle so release artifacts include the browser app ([56fa71d](https://github.com/pbi-agent/pbi-agent/commit/56fa71d)).
+- Added durable saved-session and live-run lifecycle projections so completed Kanban and saved sessions can be reviewed and continued reliably ([#247](https://github.com/pbi-agent/pbi-agent/pull/247)).
+- Added SSE-based web event streams, generated API/SSE contracts, canonical message IDs, and stronger recovery for reconnecting browser sessions ([#250](https://github.com/pbi-agent/pbi-agent/pull/250)).
+- Added a compact live context-window gauge with usage and compaction threshold details in the session UI ([#225](https://github.com/pbi-agent/pbi-agent/pull/225)).
+- Added Kanban task prompt image paste support and persisted task image attachments ([#226](https://github.com/pbi-agent/pbi-agent/pull/226)).
+- Added desktop and sound notifications for completed sessions with replay-safe deduplication ([#237](https://github.com/pbi-agent/pbi-agent/pull/237), [#238](https://github.com/pbi-agent/pbi-agent/pull/238)).
+- Added advisory dead-code validation for release and ship workflows ([#245](https://github.com/pbi-agent/pbi-agent/pull/245)).
 
 ## Changed
 
-- Hardened the web session lifecycle to improve startup, cancellation, continuation, and cleanup behavior ([4a51350](https://github.com/pbi-agent/pbi-agent/commit/4a51350), [f6d40d9](https://github.com/pbi-agent/pbi-agent/commit/f6d40d9)).
-- Strengthened Kanban task and live-run flows so task-backed sessions remain aligned with current run state ([d4028df](https://github.com/pbi-agent/pbi-agent/commit/d4028df)).
-- Refined frontend session recovery behavior to restore active and saved sessions more reliably after reloads or reconnects ([713f50a](https://github.com/pbi-agent/pbi-agent/commit/713f50a), [672eca1](https://github.com/pbi-agent/pbi-agent/commit/672eca1)).
+- Merged local PNG, JPEG, and WEBP reading into `read_file`, replacing the separate image-read tool path ([#244](https://github.com/pbi-agent/pbi-agent/pull/244)).
+- Refined web UI spacing, delete-dialog hover states, and session action affordances for more consistent controls ([#222](https://github.com/pbi-agent/pbi-agent/pull/222), [#228](https://github.com/pbi-agent/pbi-agent/pull/228), [#229](https://github.com/pbi-agent/pbi-agent/pull/229)).
+- Smoothed active session Working spinner color transitions and kept spinner state visually stable between phases ([#241](https://github.com/pbi-agent/pbi-agent/pull/241)).
 
 ## Fixed
 
-- Fixed recovery gaps that could leave resumed web sessions missing timeline events or profile context ([d4028df](https://github.com/pbi-agent/pbi-agent/commit/d4028df), [56fa71d](https://github.com/pbi-agent/pbi-agent/commit/56fa71d)).
-- Fixed saved-session handling for ask-user prompts and image attachments ([672eca1](https://github.com/pbi-agent/pbi-agent/commit/672eca1)).
+- Fixed interrupted provider history replay so incomplete tool calls are not restored without matching outputs ([#242](https://github.com/pbi-agent/pbi-agent/pull/242)).
+- Fixed saved-session timeline ordering, stale live-session selection, SSE cursor recovery, shutdown handling, and task-run lifecycle edge cases found during production hardening ([#250](https://github.com/pbi-agent/pbi-agent/pull/250)).
 
 ## Internal
 
-- Modularized session-manager internals to separate lifecycle, replay, persistence, and event-handling responsibilities ([0b0fcf5](https://github.com/pbi-agent/pbi-agent/commit/0b0fcf5)).
+- Modularized web session internals to separate lifecycle, replay, persistence, task, configuration, and event responsibilities ([#250](https://github.com/pbi-agent/pbi-agent/pull/250)).
+- Removed unreachable provider code paths and wired dead-code scanning into release validation guidance ([#245](https://github.com/pbi-agent/pbi-agent/pull/245)).
 
 Manual browser smoke remains a release gate for production-ready signoff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.1.0"
+version = "0.2.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/src/pbi_agent/log_config.py
+++ b/src/pbi_agent/log_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 def configure_logging(verbose: bool) -> None:
-    console_level = logging.DEBUG if verbose else logging.INFO
+    console_level = logging.DEBUG if verbose else logging.WARNING
 
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
 
@@ -22,7 +22,7 @@ def configure_logging(verbose: bool) -> None:
         handlers.append(file_handler)
 
     logging.basicConfig(
-        level=logging.DEBUG if verbose else logging.INFO,
+        level=logging.DEBUG if verbose else logging.WARNING,
         handlers=handlers,
         force=True,
     )

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -1,0 +1,30 @@
+import logging
+from pathlib import Path
+
+from pbi_agent.log_config import configure_logging
+
+
+def test_configure_logging_is_quiet_by_default() -> None:
+    configure_logging(verbose=False)
+
+    root_logger = logging.getLogger()
+
+    assert root_logger.level == logging.WARNING
+    assert len(root_logger.handlers) == 1
+    assert root_logger.handlers[0].level == logging.WARNING
+
+
+def test_configure_logging_verbose_enables_debug(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    configure_logging(verbose=True)
+
+    root_logger = logging.getLogger()
+
+    assert root_logger.level == logging.DEBUG
+    assert len(root_logger.handlers) == 2
+    assert root_logger.handlers[0].level == logging.DEBUG
+    assert (tmp_path / "pbi-agent-debug.log").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -920,7 +920,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Bump pbi-agent package metadata from `0.1.0` to `0.2.0`.
- Refresh the `v0.2.0` changelog with PR-linked highlights from merged work since `v0.1.0`.
- Quiet default Python CLI logging so startup/debug/info logs are hidden unless `--verbose` is used.

## Highlights
### Added
- Durable saved-session and live-run lifecycle projections for reliable review and continuation.
- SSE-based web event streams with generated API/SSE contracts and stronger recovery.
- Context-window gauge, task image paste, completed-session notifications, and dead-code validation.

### Changed
- Local image reading is handled through `read_file`.
- Web UI spacing, delete affordances, and active Working spinner behavior were refined.

### Fixed
- Interrupted provider history replay no longer restores incomplete tool calls without outputs.
- Saved-session timeline ordering, live-session selection, SSE cursor recovery, shutdown handling, and task lifecycle edge cases were hardened.
- Non-verbose CLI logging now stays quiet by default.

## Changelog
- `docs/changelog/v0.2.0.md`

## Validation
- `uv run ruff check .` passed
- `uv run ruff format --check .` passed
- `uv run python scripts/dead_code.py` passed
- `uv run pytest -q --tb=short -x` passed
- `bun run docs:build` passed
- Focused logging validation passed: `uv run pytest -q --tb=short -x tests/test_log_config.py`
- `git diff --check` passed

## Skipped or unrelated changes
- `TODO.md` is local release-session bookkeeping and was not committed.
- Publish/merge was not performed; this PR prepares the release only.