### PR TITLE
Fix chat upload image previews

### DIFF
--- a/src/pbi_agent/web/api/routes/system.py
+++ b/src/pbi_agent/web/api/routes/system.py
@@ -461,7 +461,7 @@ def expand_session_input(
 def get_uploaded_image(upload_id: UploadIdPath) -> FileResponse:
     try:
         record = load_uploaded_image_record(upload_id)
-        path = uploaded_image_path(record)
+        path = uploaded_image_path(upload_id)
     except KeyError as exc:
         raise not_found("Upload not found.") from exc
     return FileResponse(path, media_type=record.mime_type, filename=record.name)

--- a/tests/test_web_serve.py
+++ b/tests/test_web_serve.py
@@ -3975,6 +3975,10 @@ def test_saved_session_continuation_persists_uploaded_image_attachments(
             )
             assert upload_response.status_code == 200
             upload = upload_response.json()["uploads"][0]
+            preview_response = client.get(upload["preview_url"])
+            assert preview_response.status_code == 200
+            assert preview_response.headers["content-type"] == "image/png"
+            assert preview_response.content == b"\x89PNG\r\n\x1a\n"
 
             run_response = client.post(
                 f"/api/sessions/{session_id}/runs",


### PR DESCRIPTION
## Summary
- Fix uploaded image preview lookup to resolve the stored file by upload id.
- Add regression coverage that saved-session image preview URLs return the original PNG bytes.

## Local validation
- Passed: uv run ruff check .
- Passed: uv run ruff format .
- Passed: uv run python scripts/dead_code.py
- Passed: uv run pytest -q --tb=short -x
- Passed: bun run test:web
- Passed: bun run lint
- Passed: bun run typecheck
- Passed: bun run web:build
- Passed: bun run docs:build
- Passed: git diff --check

## GitHub workflow checks
- Pending; will verify with: gh pr checks <PR> --watch --fail-fast --interval 10

## Known unshipped or skipped changes
- Preserved unrelated pre-existing local work from refactor_settings_tab_design via a local stash before creating this task branch.