### PR TITLE
chore: release v0.3.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.3.0', link: '/changelog/v0.3.0' },
           { text: 'v0.2.0', link: '/changelog/v0.2.0' },
           { text: 'v0.1.0', link: '/changelog/v0.1.0' },
           { text: 'v0.0.33', link: '/changelog/v0.0.33' }

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.3.0 - 2026-05-07](./v0.3.0.md)
 - [v0.2.0 - 2026-05-05](./v0.2.0.md)
 - [v0.1.0 - 2026-04-30](./v0.1.0.md)
 - [v0.0.33 - 2026-04-30](./v0.0.33.md)

--- a/docs/changelog/v0.3.0.md
+++ b/docs/changelog/v0.3.0.md
@@ -1,0 +1,26 @@
+---
+title: v0.3.0
+description: Changelog for pbi-agent v0.3.0, released on 2026-05-07.
+---
+
+# v0.3.0
+
+**Release date:** 2026-05-07
+
+## Added
+
+- Added a packaged Docker Desktop sandbox command and bundled sandbox Dockerfile so users can launch pbi-agent in an isolated local container ([#267](https://github.com/pbi-agent/pbi-agent/pull/267)).
+- Added Kanban task titles to successful browser finish notifications while preserving the generic session-complete fallback ([#266](https://github.com/pbi-agent/pbi-agent/pull/266)).
+
+## Changed
+
+- Redesigned Settings into a two-pane surface with dedicated notification, provider, model profile, and command sections ([#253](https://github.com/pbi-agent/pbi-agent/pull/253)).
+- Refined the web Working timeline with compact grouped summaries, friendly tool labels, animated activity counts, and sub-agent drilldown behavior ([#258](https://github.com/pbi-agent/pbi-agent/pull/258)).
+- Optimized the sandbox runtime image from 887 MB to about 560 MB with an Alpine base and tighter dependency cleanup ([#267](https://github.com/pbi-agent/pbi-agent/pull/267)).
+
+## Fixed
+
+- Fixed uploaded image preview lookup so saved-session image preview URLs return the original file bytes ([#252](https://github.com/pbi-agent/pbi-agent/pull/252)).
+- Fixed transient slash-command replay so `/skills`, `/mcp`, `/agents`, and `/reload` stay live-only without advancing durable SSE cursors ([#254](https://github.com/pbi-agent/pbi-agent/pull/254)).
+- Hid generic retry countdown messages in session timelines while keeping contextual retry notices and real errors visible ([#260](https://github.com/pbi-agent/pbi-agent/pull/260)).
+- Fixed image-attached user messages so sending an image no longer jumps the session timeline upward ([#262](https://github.com/pbi-agent/pbi-agent/pull/262)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.2.0"
+version = "0.3.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -920,7 +920,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Prepare pbi-agent v0.3.0 with a minor release bump, changelog page, changelog index entry, VitePress sidebar link, and lockfile version alignment.

## Highlights
### Added
- Packaged Docker Desktop sandbox command and bundled sandbox Dockerfile for isolated local container use.
- Kanban task titles in successful browser finish notifications.

### Changed
- Redesigned Settings into a two-pane surface with dedicated settings sections.
- Refined the web Working timeline with grouped summaries, friendly tool labels, animated activity counts, and sub-agent drilldown behavior.
- Optimized the sandbox runtime image from 887 MB to about 560 MB.

### Fixed
- Uploaded image preview lookup for saved sessions.
- Transient slash-command replay for `/skills`, `/mcp`, `/agents`, and `/reload`.
- Generic retry countdown noise in session timelines.
- Image-attached user message timeline jumps.

## Changelog
- docs/changelog/v0.3.0.md

## Validation
- Passed: `uv run ruff check .`
- Passed: `uv run ruff format --check .`
- Passed: `uv run python scripts/dead_code.py`
- Passed: `uv run pytest -q --tb=short -x`
- Passed: `bun run docs:build`

## Skipped or unrelated changes
- Left session-local `TODO.md` uncommitted.
