### PR TITLE
Add BasedPyright dev checks

### DIFF
--- a/.agents/commands/commit.md
+++ b/.agents/commands/commit.md
@@ -29,7 +29,7 @@ Do not commit failing or unvalidated changes. Validation must be current enough 
    - If relevant validation already passed after the latest edits, reuse that evidence.
    - Always run `git diff --check` before commit.
    - If validation is missing or stale, run focused commands for the touched surface:
-     - Python: relevant pytest plus `uv run ruff check ...` and `uv run ruff format --check ...`
+     - Python: relevant pytest plus `uv run ruff check ...`, `uv run ruff format --check ...`, and `uv run basedpyright`
      - Frontend: relevant `bun run test:web -- ...`, plus `bun run lint`, `bun run typecheck`, and `bun run web:build` when frontend build/static assets are touched
      - Docs: `bun run docs:build` when docs are touched
    - Stop if validation fails unless failure is clearly unrelated and documented.

--- a/.agents/commands/orchestrate.md
+++ b/.agents/commands/orchestrate.md
@@ -142,7 +142,7 @@ If review fails:
 Run validation for every touched surface.
 
 Common final checks:
-- Python: `uv run ruff check .`, `uv run ruff format --check .`, `uv run pytest -q --tb=short -x`
+- Python: `uv run ruff check .`, `uv run ruff format --check .`, `uv run basedpyright`, `uv run pytest -q --tb=short -x`
 - Frontend: `bun run test:web -- --maxWorkers=2`, `bun run lint`, `bun run typecheck`, `bun run web:build`
 - API/SSE contract changes: run the project codegen command and codegen tests
 - Static web assets: verify rebuilt hashed chunks are tracked

--- a/.agents/commands/release.md
+++ b/.agents/commands/release.md
@@ -81,6 +81,7 @@ When user asks to continue, merge, or publish existing release workflow:
 11. Validate:
    - `uv run ruff check .`
    - `uv run ruff format --check .`
+   - `uv run basedpyright`
    - `uv run python scripts/dead_code.py`
    - `uv run pytest -q --tb=short -x`
    - `bun run docs:build`

--- a/.agents/commands/ship-task.md
+++ b/.agents/commands/ship-task.md
@@ -48,7 +48,7 @@ Stop without shipping if:
 1. Start with `git status --short --branch` and inspect the diff before making Git changes.
 2. Identify current task scope from diff and available session context. Prefer explicit file paths when staging.
 3. Run focused validation for the touched surfaces before committing, then verify the full Python and web test suites pass before shipping:
-   - Python: `uv run ruff check .`, `uv run ruff format .`, `uv run python scripts/dead_code.py`, and full `uv run pytest -q --tb=short -x`.
+   - Python: `uv run ruff check .`, `uv run ruff format .`, `uv run basedpyright`, `uv run python scripts/dead_code.py`, and full `uv run pytest -q --tb=short -x`.
    - Frontend: `bun run test:web`, `bun run lint`, `bun run typecheck`, and `bun run web:build`.
    - Docs: `bun run docs:build`.
    - Broad changes: run repo-level checks from project instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ bun run test:web
 bun run test:web:watch
 uv run ruff check .
 uv run ruff format .
+uv run basedpyright
 bun run lint
 bun run lint:fix
 bun run typecheck
@@ -106,8 +107,8 @@ uv tool install --reinstall .
 - Workspace confinement: `shell` tool rejects path traversal; all file tools validate paths against workspace boundaries.
 - Keep the web implementation aligned with the current FastAPI backend plus Vite/React frontend; do not introduce a parallel web framework or client stack.
 - Validation by touched surface:
-  - Python changes: `uv run ruff check .`, `uv run ruff format --check .`, and the relevant `uv run pytest -q --tb=short -x ...` scope.
+  - Python changes: `uv run ruff check .`, `uv run ruff format --check .`, `uv run basedpyright`, and the relevant `uv run pytest -q --tb=short -x ...` scope.
   - Frontend changes: `bun run test:web`, `bun run lint`, `bun run typecheck`, and `bun run web:build`.
   - Docs changes: `bun run docs:build`.
-- Before handoff on broad changes, the repo-level checks are `uv run ruff check .`, `uv run ruff format --check .`, `bun run lint`, `bun run typecheck`, and `uv run pytest -q --tb=short -x`.
+- Before handoff on broad changes, the repo-level checks are `uv run ruff check .`, `uv run ruff format --check .`, `uv run basedpyright`, `bun run lint`, `bun run typecheck`, and `uv run pytest -q --tb=short -x`.
 - **No migration or backward-compatibility logic.** The project is in early development — do not add schema migrations, version checks, deprecation shims, or any other backward-compatibility code. When something changes, just change it directly.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -8,7 +8,7 @@
 ## Long-Term Memory
 - Memory: token-efficient; keep durable decisions/follow-ups only, not logs.
 - Workflow: no commit/push/merge/PR unless asked. Use session-only `TODO.md`; markers `[ ]`, `[>]`, `[X]`, `[!]`, `[-]`. Shell from workspace root; use `python3` for direct Python shell commands.
-- Validate touched surface: Python Ruff+pytest; frontend Bun tests/lint/typecheck/build; docs build. Note skipped/hung checks.
+- Validate touched surface: Python Ruff+basedpyright+pytest; frontend Bun tests/lint/typecheck/build; docs build. Note skipped/hung checks.
 - Architecture: CLI `src/pbi_agent/__main__.py` -> `src/pbi_agent/cli.py`; default command `web`; backend FastAPI `src/pbi_agent/web/`; frontend Vite React `webapp/`.
 - API changes: align routes/schemas/session manager with `webapp/src/api.ts` + `webapp/src/types.ts`.
 - Web API contract: `bun run web:api-types` runs `scripts/generate_api_types.py` to regenerate `webapp/src/api-types.generated.ts` from FastAPI OpenAPI plus extra SSE models; output includes schema types, SSE event unions, `ApiOperationResponses`, and `ApiJsonRequestBodies`. Pytest `test_api_types_codegen.py` enforces generated output is current.
@@ -105,3 +105,4 @@
 - Diagnosed session `ee5f63efde2b4af2bc4b3970060e9439`: resumed run `a9760a30f85f48a28e74766b69306595` failed during a 4-tool iteration because `ThreadPoolExecutor.submit()` raised `RuntimeError: can't start new thread`. Fixed shared tool runtime to warm worker threads before submitting tool calls, retry with fewer workers on thread-start exhaustion, then fall back to serial execution if needed. Validation: `uv run pytest -q --tb=short -x tests/test_tool_runtime.py`, Ruff check/format-check for touched files, and `git diff --check` passed.
 - Removed `SettingsPage.test.tsx` React `act(...)` warning noise by wrapping settings-dialog Zustand open/close setup in `act`; product code unchanged. Validation: `bun run test:web -- SettingsPage`, `bun run test:web` (one transient unrelated first-run timeout, rerun passed), `bun run lint`, `bun run typecheck`, and `git diff --check` passed.
 - Added GitHub CLI (`gh`, Alpine package `github-cli`) to the sandbox image package list and updated sandbox docs/tests to mention it. Validation: focused sandbox pytest, Ruff check/format-check for `tests/test_cli.py`, docs build, and `git diff --check` passed.
+- Prepared BasedPyright dev workflow for shipping without re-running BasedPyright per user request; local validation used Ruff, format, dead-code, full Python pytest, web tests/lint/typecheck/build, and docs build. Next: GitHub checks pending after PR.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
-[X] Locate sandbox image package list
-[X] Add GitHub CLI to sandbox image
-[X] Update tests/docs if needed
-[X] Run focused validation
-[X] Update memory
+# TODO
+
+[X] Inspect task-scoped changes
+[X] Run validation excluding basedpyright per request
+[X] Prepare branch for shipping

--- a/basedpyright-analysis.md
+++ b/basedpyright-analysis.md
@@ -1,0 +1,355 @@
+# BasedPyright diagnostics analysis
+
+Total: 315 errors; files analyzed: 122
+
+## By rule
+
+- 288: `reportAttributeAccessIssue`
+- 17: `reportArgumentType`
+- 3: `reportOptionalMemberAccess`
+- 2: `reportAbstractUsage`
+- 2: `reportCallIssue`
+- 1: `reportOperatorIssue`
+- 1: `reportReturnType`
+- 1: `reportRedeclaration`
+
+## By file
+
+- 81: `src/pbi_agent/web/session/tasks.py`
+- 64: `src/pbi_agent/web/session/workers.py`
+- 43: `src/pbi_agent/web/session/live_sessions.py`
+- 39: `src/pbi_agent/web/session/provider_auth.py`
+- 24: `src/pbi_agent/web/session/saved_sessions.py`
+- 15: `src/pbi_agent/web/session/catalogs.py`
+- 13: `src/pbi_agent/web/session/events.py`
+- 11: `src/pbi_agent/web/session/configuration.py`
+- 4: `src/pbi_agent/tools/sub_agent.py`
+- 3: `src/pbi_agent/cli.py`
+- 3: `src/pbi_agent/project_sources.py`
+- 3: `src/pbi_agent/providers/xai_provider.py`
+- 3: `src/pbi_agent/session_store.py`
+- 2: `src/pbi_agent/agent/error_formatting.py`
+- 2: `src/pbi_agent/providers/openai_provider.py`
+- 1: `src/pbi_agent/auth/usage_limits.py`
+- 1: `src/pbi_agent/config.py`
+- 1: `src/pbi_agent/display/console_display.py`
+- 1: `src/pbi_agent/tools/read_file.py`
+- 1: `src/pbi_agent/web/server_runtime.py`
+
+## All diagnostics
+
+- `src/pbi_agent/agent/error_formatting.py:223:43` `reportOptionalMemberAccess` "strip" is not a known attribute of "None"
+- `src/pbi_agent/agent/error_formatting.py:225:52` `reportOptionalMemberAccess` "strip" is not a known attribute of "None"
+- `src/pbi_agent/auth/usage_limits.py:340:34` `reportOperatorIssue` Operator "-" not supported for types "Literal[100]" and "float | None"   Operator "-" not supported for types "Literal[100]" and "None" when expected type is "float | None"
+- `src/pbi_agent/cli.py:2531:15` `reportAbstractUsage` Cannot instantiate abstract class "ConsoleDisplay"   "DisplayProtocol.request_interrupt" is not implemented   "DisplayProtocol.clear_interrupt" is not implemented   and 2 more...
+- `src/pbi_agent/cli.py:2596:16` `reportAttributeAccessIssue` Cannot access attribute "serve" for class "object"   Attribute "serve" is unknown
+- `src/pbi_agent/cli.py:2906:18` `reportArgumentType` Argument of type "ResolvedRuntime" cannot be assigned to parameter "settings" of type "Settings" in function "__init__"   "ResolvedRuntime" is not assignable to "Settings"
+- `src/pbi_agent/config.py:1416:25` `reportArgumentType` Argument of type "str | None" cannot be assigned to parameter "provider_id" of type "str" in function "_concrete_profile_for_settings"   Type "str | None" is not assignable to type "str"     "None" is not assignable to "str"
+- `src/pbi_agent/display/console_display.py:132:16` `reportAbstractUsage` Cannot instantiate abstract class "ConsoleSubAgentDisplay"   "DisplayProtocol.request_interrupt" is not implemented   "DisplayProtocol.clear_interrupt" is not implemented   and 2 more...
+- `src/pbi_agent/project_sources.py:198:16` `reportReturnType` Type "str | None" is not assignable to return type "str"   Type "str | None" is not assignable to type "str"     "None" is not assignable to "str"
+- `src/pbi_agent/project_sources.py:263:12` `reportCallIssue` No overloads for "quote" match the provided arguments
+- `src/pbi_agent/project_sources.py:263:31` `reportArgumentType` Argument of type "str | None" cannot be assigned to parameter "string" of type "bytes | bytearray" in function "quote"   Type "str | None" is not assignable to type "bytes | bytearray"     Type "str" is not assignable to type "bytes | bytearray"       "str" is not assignable to "bytes"       "str" is not assignable to "bytearray"
+- `src/pbi_agent/providers/openai_provider.py:1570:13` `reportArgumentType` Argument of type "list[Any]" cannot be assigned to parameter "value" of type "str" in function "__setitem__"   "list[Any]" is not assignable to "str"
+- `src/pbi_agent/providers/openai_provider.py:1572:13` `reportArgumentType` Argument of type "list[Any]" cannot be assigned to parameter "value" of type "str" in function "__setitem__"   "list[Any]" is not assignable to "str"
+- `src/pbi_agent/providers/xai_provider.py:703:41` `reportAttributeAccessIssue` Cannot access attribute "title" for class "dict[str, str]"   Attribute "title" is unknown
+- `src/pbi_agent/providers/xai_provider.py:704:39` `reportAttributeAccessIssue` Cannot access attribute "url" for class "dict[str, str]"   Attribute "url" is unknown
+- `src/pbi_agent/providers/xai_provider.py:705:43` `reportAttributeAccessIssue` Cannot access attribute "snippet" for class "dict[str, str]"   Attribute "snippet" is unknown
+- `src/pbi_agent/session_store.py:527:27` `reportArgumentType` Argument of type "Unknown | None" cannot be assigned to parameter "upload_id" of type "str" in function "__init__"   Type "Unknown | None" is not assignable to type "str"     "None" is not assignable to "str"
+- `src/pbi_agent/session_store.py:528:22` `reportArgumentType` Argument of type "Unknown | None" cannot be assigned to parameter "name" of type "str" in function "__init__"   Type "Unknown | None" is not assignable to type "str"     "None" is not assignable to "str"
+- `src/pbi_agent/session_store.py:529:27` `reportArgumentType` Argument of type "Unknown | None" cannot be assigned to parameter "mime_type" of type "str" in function "__init__"   Type "Unknown | None" is not assignable to type "str"     "None" is not assignable to "str"
+- `src/pbi_agent/tools/read_file.py:193:9` `reportRedeclaration` Declaration "sheets" is obscured by a declaration of the same name
+- `src/pbi_agent/tools/sub_agent.py:115:9` `reportArgumentType` Argument of type "Settings | None" cannot be assigned to parameter "settings" of type "Settings" in function "run_sub_agent_task"   Type "Settings | None" is not assignable to type "Settings"     "None" is not assignable to "Settings"
+- `src/pbi_agent/tools/sub_agent.py:116:9` `reportArgumentType` Argument of type "DisplayProtocol | None" cannot be assigned to parameter "display" of type "DisplayProtocol" in function "run_sub_agent_task"   Type "DisplayProtocol | None" is not assignable to type "DisplayProtocol"     "None" is incompatible with protocol "DisplayProtocol"       "verbose" is not present       "bind_session" is not present       "request_shutdown" is not present       "request_interrupt" is not present       "clear_interrupt" is not present       "interrupt_requested" is not present   ...
+- `src/pbi_agent/tools/sub_agent.py:117:30` `reportArgumentType` Argument of type "TokenUsage | None" cannot be assigned to parameter "parent_session_usage" of type "TokenUsage" in function "run_sub_agent_task"   Type "TokenUsage | None" is not assignable to type "TokenUsage"     "None" is not assignable to "TokenUsage"
+- `src/pbi_agent/tools/sub_agent.py:118:27` `reportArgumentType` Argument of type "TokenUsage | None" cannot be assigned to parameter "parent_turn_usage" of type "TokenUsage" in function "run_sub_agent_task"   Type "TokenUsage | None" is not assignable to type "TokenUsage"     "None" is not assignable to "TokenUsage"
+- `src/pbi_agent/web/server_runtime.py:195:18` `reportArgumentType` Argument of type "ResolvedRuntime | Settings" cannot be assigned to parameter "settings" of type "Settings" in function "__init__"   Type "ResolvedRuntime | Settings" is not assignable to type "Settings"     "ResolvedRuntime" is not assignable to "Settings"
+- `src/pbi_agent/web/session/catalogs.py:15:14` `reportAttributeAccessIssue` Cannot access attribute "_mention_index" for class "CatalogsMixin*"   Attribute "_mention_index" is unknown
+- `src/pbi_agent/web/session/catalogs.py:18:14` `reportAttributeAccessIssue` Cannot access attribute "_mention_index" for class "CatalogsMixin*"   Attribute "_mention_index" is unknown
+- `src/pbi_agent/web/session/catalogs.py:19:14` `reportAttributeAccessIssue` Cannot access attribute "_mention_index" for class "CatalogsMixin*"   Attribute "_mention_index" is unknown
+- `src/pbi_agent/web/session/catalogs.py:27:21` `reportAttributeAccessIssue` Cannot access attribute "_mention_index" for class "CatalogsMixin*"   Attribute "_mention_index" is unknown
+- `src/pbi_agent/web/session/catalogs.py:30:32` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime_optional" for class "CatalogsMixin*"   Attribute "_resolve_runtime_optional" is unknown
+- `src/pbi_agent/web/session/catalogs.py:32:40` `reportAttributeAccessIssue` Cannot access attribute "_workspace_root" for class "CatalogsMixin*"   Attribute "_workspace_root" is unknown
+- `src/pbi_agent/web/session/catalogs.py:33:35` `reportAttributeAccessIssue` Cannot access attribute "_workspace_context" for class "CatalogsMixin*"   Attribute "_workspace_context" is unknown
+- `src/pbi_agent/web/session/catalogs.py:34:44` `reportAttributeAccessIssue` Cannot access attribute "_workspace_context" for class "CatalogsMixin*"   Attribute "_workspace_context" is unknown
+- `src/pbi_agent/web/session/catalogs.py:35:32` `reportAttributeAccessIssue` Cannot access attribute "_workspace_context" for class "CatalogsMixin*"   Attribute "_workspace_context" is unknown
+- `src/pbi_agent/web/session/catalogs.py:50:30` `reportAttributeAccessIssue` Cannot access attribute "list_sessions" for class "CatalogsMixin*"   Attribute "list_sessions" is unknown
+- `src/pbi_agent/web/session/catalogs.py:51:27` `reportAttributeAccessIssue` Cannot access attribute "list_tasks" for class "CatalogsMixin*"   Attribute "list_tasks" is unknown
+- `src/pbi_agent/web/session/catalogs.py:53:22` `reportAttributeAccessIssue` Cannot access attribute "_serialize_live_session" for class "CatalogsMixin*"   Attribute "_serialize_live_session" is unknown
+- `src/pbi_agent/web/session/catalogs.py:54:34` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "CatalogsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/catalogs.py:56:34` `reportAttributeAccessIssue` Cannot access attribute "list_board_stages" for class "CatalogsMixin*"   Attribute "list_board_stages" is unknown
+- `src/pbi_agent/web/session/catalogs.py:74:50` `reportAttributeAccessIssue` Cannot access attribute "_workspace_root" for class "CatalogsMixin*"   Attribute "_workspace_root" is unknown
+- `src/pbi_agent/web/session/configuration.py:77:47` `reportAttributeAccessIssue` Cannot access attribute "_workspace_root" for class "ConfigurationMixin*"   Attribute "_workspace_root" is unknown
+- `src/pbi_agent/web/session/configuration.py:212:26` `reportAttributeAccessIssue` Cannot access attribute "_default_runtime" for class "ConfigurationMixin*"   Attribute "_default_runtime" is unknown
+- `src/pbi_agent/web/session/configuration.py:423:21` `reportAttributeAccessIssue` Cannot access attribute "_runtime_args" for class "ConfigurationMixin*"   Attribute "_runtime_args" is unknown
+- `src/pbi_agent/web/session/configuration.py:424:29` `reportAttributeAccessIssue` Cannot access attribute "_default_runtime" for class "ConfigurationMixin*"   Attribute "_default_runtime" is unknown
+- `src/pbi_agent/web/session/configuration.py:425:53` `reportAttributeAccessIssue` Cannot access attribute "_default_runtime" for class "ConfigurationMixin*"   Attribute "_default_runtime" is unknown
+- `src/pbi_agent/web/session/configuration.py:428:26` `reportAttributeAccessIssue` Cannot access attribute "_default_runtime" for class "ConfigurationMixin*"   Attribute "_default_runtime" is unknown
+- `src/pbi_agent/web/session/configuration.py:447:21` `reportAttributeAccessIssue` Cannot access attribute "_default_runtime" for class "ConfigurationMixin*"   Attribute "_default_runtime" is unknown
+- `src/pbi_agent/web/session/configuration.py:460:55` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "ConfigurationMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/configuration.py:482:59` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "ConfigurationMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/configuration.py:495:14` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "ConfigurationMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/configuration.py:617:54` `reportAttributeAccessIssue` Cannot access attribute "_workspace_root" for class "ConfigurationMixin*"   Attribute "_workspace_root" is unknown
+- `src/pbi_agent/web/session/events.py:25:25` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "EventsMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/events.py:26:29` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "EventsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/events.py:42:34` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "EventsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/events.py:47:14` `reportAttributeAccessIssue` Cannot access attribute "_require_saved_session" for class "EventsMixin*"   Attribute "_require_saved_session" is unknown
+- `src/pbi_agent/web/session/events.py:48:29` `reportAttributeAccessIssue` Cannot access attribute "_find_stream_live_session_for_saved_session" for class "EventsMixin*"   Attribute "_find_stream_live_session_for_saved_session" is unknown
+- `src/pbi_agent/web/session/events.py:69:14` `reportAttributeAccessIssue` Cannot access attribute "_require_saved_session" for class "EventsMixin*"   Attribute "_require_saved_session" is unknown
+- `src/pbi_agent/web/session/events.py:70:29` `reportAttributeAccessIssue` Cannot access attribute "_find_stream_live_session_for_saved_session" for class "EventsMixin*"   Attribute "_find_stream_live_session_for_saved_session" is unknown
+- `src/pbi_agent/web/session/events.py:95:14` `reportAttributeAccessIssue` Cannot access attribute "_require_saved_session" for class "EventsMixin*"   Attribute "_require_saved_session" is unknown
+- `src/pbi_agent/web/session/events.py:96:29` `reportAttributeAccessIssue` Cannot access attribute "_find_stream_live_session_for_saved_session" for class "EventsMixin*"   Attribute "_find_stream_live_session_for_saved_session" is unknown
+- `src/pbi_agent/web/session/events.py:143:65` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "EventsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/events.py:149:54` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "EventsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/events.py:194:31` `reportAttributeAccessIssue` Cannot access attribute "_serialize_live_snapshot" for class "EventsMixin*"   Attribute "_serialize_live_snapshot" is unknown
+- `src/pbi_agent/web/session/events.py:207:29` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "EventsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:49:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "LiveSessionsMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:50:34` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "LiveSessionsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:68:24` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime" for class "LiveSessionsMixin*"   Attribute "_resolve_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:70:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "LiveSessionsMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:72:22` `reportAttributeAccessIssue` Cannot access attribute "_require_saved_session" for class "LiveSessionsMixin*"   Attribute "_require_saved_session" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:74:36` `reportAttributeAccessIssue` Cannot access attribute "_resolve_saved_session_runtime" for class "LiveSessionsMixin*"   Attribute "_resolve_saved_session_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:79:26` `reportAttributeAccessIssue` Cannot access attribute "_update_saved_session_runtime" for class "LiveSessionsMixin*"   Attribute "_update_saved_session_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:86:60` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "LiveSessionsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:88:26` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "LiveSessionsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:90:18` `reportAttributeAccessIssue` Cannot access attribute "_ensure_worker_creation_allowed_locked" for class "LiveSessionsMixin*"   Attribute "_ensure_worker_creation_allowed_locked" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:100:26` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "LiveSessionsMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:117:29` `reportAttributeAccessIssue` Cannot access attribute "_run_session_worker" for class "LiveSessionsMixin*"   Attribute "_run_session_worker" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:132:18` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "LiveSessionsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:135:18` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "LiveSessionsMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:145:18` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "LiveSessionsMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:155:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "LiveSessionsMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:165:22` `reportAttributeAccessIssue` Cannot access attribute "_finalize_live_session_locked" for class "LiveSessionsMixin*"   Attribute "_finalize_live_session_locked" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:209:14` `reportAttributeAccessIssue` Cannot access attribute "_require_saved_session" for class "LiveSessionsMixin*"   Attribute "_require_saved_session" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:244:34` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime" for class "LiveSessionsMixin*"   Attribute "_resolve_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:251:47` `reportAttributeAccessIssue` Cannot access attribute "_workspace_root" for class "LiveSessionsMixin*"   Attribute "_workspace_root" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:266:18` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "LiveSessionsMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:343:59` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "LiveSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:350:18` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "LiveSessionsMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:481:14` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "LiveSessionsMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:517:14` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "LiveSessionsMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:554:61` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "LiveSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:574:34` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime" for class "LiveSessionsMixin*"   Attribute "_resolve_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:606:34` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime" for class "LiveSessionsMixin*"   Attribute "_resolve_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:617:34` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime" for class "LiveSessionsMixin*"   Attribute "_resolve_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:620:25` `reportAttributeAccessIssue` Cannot access attribute "_update_saved_session_runtime" for class "LiveSessionsMixin*"   Attribute "_update_saved_session_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:630:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "LiveSessionsMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:638:34` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "LiveSessionsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:660:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "LiveSessionsMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:666:47` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "LiveSessionsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:676:29` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "LiveSessionsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:751:39` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "LiveSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:752:48` `reportAttributeAccessIssue` Cannot access attribute "_workspace_root" for class "LiveSessionsMixin*"   Attribute "_workspace_root" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:753:52` `reportAttributeAccessIssue` Cannot access attribute "_workspace_context" for class "LiveSessionsMixin*"   Attribute "_workspace_context" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:777:29` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "LiveSessionsMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:787:24` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime" for class "LiveSessionsMixin*"   Attribute "_resolve_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:794:18` `reportAttributeAccessIssue` Cannot access attribute "_update_saved_session_runtime" for class "LiveSessionsMixin*"   Attribute "_update_saved_session_runtime" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:799:14` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "LiveSessionsMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/live_sessions.py:849:14` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "LiveSessionsMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:39:25` `reportAttributeAccessIssue` Cannot access attribute "_require_provider" for class "ProviderAuthMixin*"   Attribute "_require_provider" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:46:30` `reportAttributeAccessIssue` Cannot access attribute "_provider_view" for class "ProviderAuthMixin*"   Attribute "_provider_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:47:33` `reportAttributeAccessIssue` Cannot access attribute "_auth_status_view" for class "ProviderAuthMixin*"   Attribute "_auth_status_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:63:25` `reportAttributeAccessIssue` Cannot access attribute "_require_provider" for class "ProviderAuthMixin*"   Attribute "_require_provider" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:84:30` `reportAttributeAccessIssue` Cannot access attribute "_provider_view" for class "ProviderAuthMixin*"   Attribute "_provider_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:85:33` `reportAttributeAccessIssue` Cannot access attribute "_auth_status_view" for class "ProviderAuthMixin*"   Attribute "_auth_status_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:86:29` `reportAttributeAccessIssue` Cannot access attribute "_auth_session_view" for class "ProviderAuthMixin*"   Attribute "_auth_session_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:91:25` `reportAttributeAccessIssue` Cannot access attribute "_require_provider" for class "ProviderAuthMixin*"   Attribute "_require_provider" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:103:30` `reportAttributeAccessIssue` Cannot access attribute "_provider_view" for class "ProviderAuthMixin*"   Attribute "_provider_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:104:33` `reportAttributeAccessIssue` Cannot access attribute "_auth_status_view" for class "ProviderAuthMixin*"   Attribute "_auth_status_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:105:29` `reportAttributeAccessIssue` Cannot access attribute "_auth_session_view" for class "ProviderAuthMixin*"   Attribute "_auth_session_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:110:25` `reportAttributeAccessIssue` Cannot access attribute "_require_provider" for class "ProviderAuthMixin*"   Attribute "_require_provider" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:118:30` `reportAttributeAccessIssue` Cannot access attribute "_provider_view" for class "ProviderAuthMixin*"   Attribute "_provider_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:119:33` `reportAttributeAccessIssue` Cannot access attribute "_auth_status_view" for class "ProviderAuthMixin*"   Attribute "_auth_status_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:125:25` `reportAttributeAccessIssue` Cannot access attribute "_require_provider" for class "ProviderAuthMixin*"   Attribute "_require_provider" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:137:25` `reportAttributeAccessIssue` Cannot access attribute "_require_provider" for class "ProviderAuthMixin*"   Attribute "_require_provider" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:187:27` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "ProviderAuthMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:188:26` `reportAttributeAccessIssue` Cannot access attribute "_provider_auth_flows" for class "ProviderAuthMixin*"   Attribute "_provider_auth_flows" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:196:27` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "ProviderAuthMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:197:37` `reportAttributeAccessIssue` Cannot access attribute "_provider_auth_flows" for class "ProviderAuthMixin*"   Attribute "_provider_auth_flows" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:199:30` `reportAttributeAccessIssue` Cannot access attribute "_provider_auth_flows" for class "ProviderAuthMixin*"   Attribute "_provider_auth_flows" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:224:23` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "ProviderAuthMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:225:22` `reportAttributeAccessIssue` Cannot access attribute "_provider_auth_flows" for class "ProviderAuthMixin*"   Attribute "_provider_auth_flows" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:227:30` `reportAttributeAccessIssue` Cannot access attribute "_provider_view" for class "ProviderAuthMixin*"   Attribute "_provider_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:228:33` `reportAttributeAccessIssue` Cannot access attribute "_auth_status_view" for class "ProviderAuthMixin*"   Attribute "_auth_status_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:234:25` `reportAttributeAccessIssue` Cannot access attribute "_require_provider" for class "ProviderAuthMixin*"   Attribute "_require_provider" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:242:30` `reportAttributeAccessIssue` Cannot access attribute "_provider_view" for class "ProviderAuthMixin*"   Attribute "_provider_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:243:33` `reportAttributeAccessIssue` Cannot access attribute "_auth_status_view" for class "ProviderAuthMixin*"   Attribute "_auth_status_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:245:29` `reportAttributeAccessIssue` Cannot access attribute "_auth_session_view" for class "ProviderAuthMixin*"   Attribute "_auth_session_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:250:25` `reportAttributeAccessIssue` Cannot access attribute "_require_provider" for class "ProviderAuthMixin*"   Attribute "_require_provider" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:279:30` `reportAttributeAccessIssue` Cannot access attribute "_provider_view" for class "ProviderAuthMixin*"   Attribute "_provider_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:280:33` `reportAttributeAccessIssue` Cannot access attribute "_auth_status_view" for class "ProviderAuthMixin*"   Attribute "_auth_status_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:282:29` `reportAttributeAccessIssue` Cannot access attribute "_auth_session_view" for class "ProviderAuthMixin*"   Attribute "_auth_session_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:296:25` `reportAttributeAccessIssue` Cannot access attribute "_require_provider" for class "ProviderAuthMixin*"   Attribute "_require_provider" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:334:30` `reportAttributeAccessIssue` Cannot access attribute "_provider_view" for class "ProviderAuthMixin*"   Attribute "_provider_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:335:33` `reportAttributeAccessIssue` Cannot access attribute "_auth_status_view" for class "ProviderAuthMixin*"   Attribute "_auth_status_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:337:29` `reportAttributeAccessIssue` Cannot access attribute "_auth_session_view" for class "ProviderAuthMixin*"   Attribute "_auth_session_view" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:360:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "ProviderAuthMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/provider_auth.py:361:25` `reportAttributeAccessIssue` Cannot access attribute "_provider_auth_flows" for class "ProviderAuthMixin*"   Attribute "_provider_auth_flows" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:24:22` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:48:42` `reportAttributeAccessIssue` Cannot access attribute "_find_live_session_for_saved_session" for class "SavedSessionsMixin*"   Attribute "_find_live_session_for_saved_session" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:64:24` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime" for class "SavedSessionsMixin*"   Attribute "_resolve_runtime" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:67:22` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:78:14` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "SavedSessionsMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:84:59` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:91:29` `reportAttributeAccessIssue` Cannot access attribute "_find_live_session_for_saved_session" for class "SavedSessionsMixin*"   Attribute "_find_live_session_for_saved_session" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:93:18` `reportAttributeAccessIssue` Cannot access attribute "_serialize_live_session" for class "SavedSessionsMixin*"   Attribute "_serialize_live_session" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:103:18` `reportAttributeAccessIssue` Cannot access attribute "_serialize_live_snapshot" for class "SavedSessionsMixin*"   Attribute "_serialize_live_snapshot" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:136:59` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:143:14` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "SavedSessionsMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:149:61` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:163:65` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:182:52` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:204:52` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:226:60` `reportArgumentType` Argument of type "object" cannot be assigned to parameter "raw_value" of type "str | None" in function "_deserialize_json_field"   Type "object" is not assignable to type "str | None"     "object" is not assignable to "str"     "object" is not assignable to "None"
+- `src/pbi_agent/web/session/saved_sessions.py:238:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "SavedSessionsMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:239:21` `reportAttributeAccessIssue` Cannot access attribute "_find_live_session_for_saved_session_locked" for class "SavedSessionsMixin*"   Attribute "_find_live_session_for_saved_session_locked" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:248:45` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:253:62` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:257:42` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "SavedSessionsMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:272:62` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:290:18` `reportAttributeAccessIssue` Cannot access attribute "_publish_task_updated" for class "SavedSessionsMixin*"   Attribute "_publish_task_updated" is unknown
+- `src/pbi_agent/web/session/saved_sessions.py:295:55` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "SavedSessionsMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:41:52` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:44:66` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:49:30` `reportAttributeAccessIssue` Cannot access attribute "_resolve_task_runtime" for class "TasksMixin*"   Attribute "_resolve_task_runtime" is unknown
+- `src/pbi_agent/web/session/tasks.py:59:60` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:68:25` `reportAttributeAccessIssue` Cannot access attribute "_profile_map" for class "TasksMixin*"   Attribute "_profile_map" is unknown
+- `src/pbi_agent/web/session/tasks.py:69:25` `reportAttributeAccessIssue` Cannot access attribute "_command_map" for class "TasksMixin*"   Attribute "_command_map" is unknown
+- `src/pbi_agent/web/session/tasks.py:112:22` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:116:14` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "TasksMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/tasks.py:132:18` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime" for class "TasksMixin*"   Attribute "_resolve_runtime" is unknown
+- `src/pbi_agent/web/session/tasks.py:138:34` `reportAttributeAccessIssue` Cannot access attribute "_message_attachments_for_upload_ids" for class "TasksMixin*"   Attribute "_message_attachments_for_upload_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:143:32` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:144:23` `reportArgumentType` Argument of type "str | None" cannot be assigned to parameter "title" of type "str" in function "create_kanban_task"   Type "str | None" is not assignable to type "str"     "None" is not assignable to "str"
+- `src/pbi_agent/web/session/tasks.py:145:24` `reportArgumentType` Argument of type "str | None" cannot be assigned to parameter "prompt" of type "str" in function "create_kanban_task"   Type "str | None" is not assignable to type "str"     "None" is not assignable to "str"
+- `src/pbi_agent/web/session/tasks.py:171:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:172:32` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:174:18` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:180:22` `reportAttributeAccessIssue` Cannot access attribute "_resolve_runtime" for class "TasksMixin*"   Attribute "_resolve_runtime" is unknown
+- `src/pbi_agent/web/session/tasks.py:182:22` `reportAttributeAccessIssue` Cannot access attribute "_message_attachments_for_upload_ids" for class "TasksMixin*"   Attribute "_message_attachments_for_upload_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:188:65` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:235:27` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:236:26` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:239:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:240:32` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:242:18` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:246:63` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:251:18` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "TasksMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/tasks.py:253:23` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:254:22` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:265:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:266:18` `reportAttributeAccessIssue` Cannot access attribute "_ensure_worker_creation_allowed_locked" for class "TasksMixin*"   Attribute "_ensure_worker_creation_allowed_locked" is unknown
+- `src/pbi_agent/web/session/tasks.py:267:62` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:269:18` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:279:63` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:280:31` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:281:30` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:285:35` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:286:34` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:296:35` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:297:34` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:303:35` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:304:34` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:313:26` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:316:32` `reportAttributeAccessIssue` Cannot access attribute "_resolve_task_runtime" for class "TasksMixin*"   Attribute "_resolve_task_runtime" is unknown
+- `src/pbi_agent/web/session/tasks.py:354:40` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:366:35` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:367:34` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:395:72` `reportOptionalMemberAccess` "id" is not a known attribute of "None"
+- `src/pbi_agent/web/session/tasks.py:398:27` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:399:26` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:416:29` `reportAttributeAccessIssue` Cannot access attribute "_run_task_worker" for class "TasksMixin*"   Attribute "_run_task_worker" is unknown
+- `src/pbi_agent/web/session/tasks.py:421:23` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:422:22` `reportAttributeAccessIssue` Cannot access attribute "_ensure_worker_creation_allowed_locked" for class "TasksMixin*"   Attribute "_ensure_worker_creation_allowed_locked" is unknown
+- `src/pbi_agent/web/session/tasks.py:424:22` `reportAttributeAccessIssue` Cannot access attribute "_task_workers" for class "TasksMixin*"   Attribute "_task_workers" is unknown
+- `src/pbi_agent/web/session/tasks.py:432:31` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:433:30` `reportAttributeAccessIssue` Cannot access attribute "_task_workers" for class "TasksMixin*"   Attribute "_task_workers" is unknown
+- `src/pbi_agent/web/session/tasks.py:436:27` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:437:26` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "TasksMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/tasks.py:451:35` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:454:55` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "TasksMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/tasks.py:462:35` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:463:34` `reportAttributeAccessIssue` Cannot access attribute "_finalize_live_session_locked" for class "TasksMixin*"   Attribute "_finalize_live_session_locked" is unknown
+- `src/pbi_agent/web/session/tasks.py:466:22` `reportAttributeAccessIssue` Cannot access attribute "_finalize_shutdown_if_idle" for class "TasksMixin*"   Attribute "_finalize_shutdown_if_idle" is unknown
+- `src/pbi_agent/web/session/tasks.py:482:27` `reportArgumentType` Argument of type "(event_type: str, payload: dict[str, Any], current: str = new_live_session_id) -> (dict[str, Any] | None)" cannot be assigned to parameter "publish_event" of type "EventPublisher" in function "__init__"   Type "(event_type: str, payload: dict[str, Any], current: str = new_live_session_id) -> (dict[str, Any] | None)" is not assignable to type "EventPublisher"     Function return type "dict[str, Any] | None" is incompatible with type "None"       Type "dict[str, Any] | None" is not assignable to type "None"         "dict[str, Any]" is not assignable to "None"
+- `src/pbi_agent/web/session/tasks.py:494:22` `reportAttributeAccessIssue` Cannot access attribute "_bind_live_session" for class "TasksMixin*"   Attribute "_bind_live_session" is unknown
+- `src/pbi_agent/web/session/tasks.py:511:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "TasksMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/tasks.py:512:18` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "TasksMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/tasks.py:513:14` `reportAttributeAccessIssue` Cannot access attribute "_create_live_run_projection" for class "TasksMixin*"   Attribute "_create_live_run_projection" is unknown
+- `src/pbi_agent/web/session/tasks.py:514:14` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_session_runtime" for class "TasksMixin*"   Attribute "_publish_live_session_runtime" is unknown
+- `src/pbi_agent/web/session/tasks.py:515:14` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "TasksMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/tasks.py:525:14` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "TasksMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/tasks.py:527:35` `reportAttributeAccessIssue` Cannot access attribute "_serialize_live_session" for class "TasksMixin*"   Attribute "_serialize_live_session" is unknown
+- `src/pbi_agent/web/session/tasks.py:585:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "TasksMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/tasks.py:629:14` `reportAttributeAccessIssue` Cannot access attribute "_app_stream" for class "TasksMixin*"   Attribute "_app_stream" is unknown
+- `src/pbi_agent/web/session/tasks.py:636:26` `reportAttributeAccessIssue` Cannot access attribute "_resolve_task_runtime" for class "TasksMixin*"   Attribute "_resolve_task_runtime" is unknown
+- `src/pbi_agent/web/session/tasks.py:644:55` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:648:59` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:662:55` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:692:55` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "TasksMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/tasks.py:721:24` `reportAttributeAccessIssue` Cannot access attribute "_command_map" for class "TasksMixin*"   Attribute "_command_map" is unknown
+- `src/pbi_agent/web/session/tasks.py:770:24` `reportAttributeAccessIssue` Cannot access attribute "_workspace_root" for class "TasksMixin*"   Attribute "_workspace_root" is unknown
+- `src/pbi_agent/web/session/tasks.py:771:33` `reportAttributeAccessIssue` Cannot access attribute "_workspace_root" for class "TasksMixin*"   Attribute "_workspace_root" is unknown
+- `src/pbi_agent/web/session/workers.py:47:18` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "WorkersMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/workers.py:67:14` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_session_lifecycle" for class "WorkersMixin*"   Attribute "_publish_live_session_lifecycle" is unknown
+- `src/pbi_agent/web/session/workers.py:90:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:92:30` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "WorkersMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/workers.py:98:34` `reportAttributeAccessIssue` Cannot access attribute "_task_workers" for class "WorkersMixin*"   Attribute "_task_workers" is unknown
+- `src/pbi_agent/web/session/workers.py:102:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:103:45` `reportAttributeAccessIssue` Cannot access attribute "_provider_auth_flows" for class "WorkersMixin*"   Attribute "_provider_auth_flows" is unknown
+- `src/pbi_agent/web/session/workers.py:104:18` `reportAttributeAccessIssue` Cannot access attribute "_provider_auth_flows" for class "WorkersMixin*"   Attribute "_provider_auth_flows" is unknown
+- `src/pbi_agent/web/session/workers.py:106:18` `reportAttributeAccessIssue` Cannot access attribute "_cancel_provider_auth_flow_browser_timeout" for class "WorkersMixin*"   Attribute "_cancel_provider_auth_flow_browser_timeout" is unknown
+- `src/pbi_agent/web/session/workers.py:107:18` `reportAttributeAccessIssue` Cannot access attribute "_shutdown_provider_auth_flow_browser_listener" for class "WorkersMixin*"   Attribute "_shutdown_provider_auth_flow_browser_listener" is unknown
+- `src/pbi_agent/web/session/workers.py:111:29` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "WorkersMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/workers.py:113:14` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "WorkersMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/workers.py:123:14` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_session_lifecycle" for class "WorkersMixin*"   Attribute "_publish_live_session_lifecycle" is unknown
+- `src/pbi_agent/web/session/workers.py:129:32` `reportAttributeAccessIssue` Cannot access attribute "refresh_file_mentions_cache" for class "WorkersMixin*"   Attribute "refresh_file_mentions_cache" is unknown
+- `src/pbi_agent/web/session/workers.py:137:18` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "WorkersMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/workers.py:150:18` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "WorkersMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/workers.py:161:18` `reportAttributeAccessIssue` Cannot access attribute "refresh_file_mentions_cache" for class "WorkersMixin*"   Attribute "refresh_file_mentions_cache" is unknown
+- `src/pbi_agent/web/session/workers.py:162:23` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:173:18` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "WorkersMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/workers.py:182:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "WorkersMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/workers.py:192:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_session_lifecycle" for class "WorkersMixin*"   Attribute "_publish_live_session_lifecycle" is unknown
+- `src/pbi_agent/web/session/workers.py:199:30` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "WorkersMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/workers.py:205:32` `reportAttributeAccessIssue` Cannot access attribute "_resolve_task_runtime" for class "WorkersMixin*"   Attribute "_resolve_task_runtime" is unknown
+- `src/pbi_agent/web/session/workers.py:210:31` `reportAttributeAccessIssue` Cannot access attribute "_task_prompt_for_run" for class "WorkersMixin*"   Attribute "_task_prompt_for_run" is unknown
+- `src/pbi_agent/web/session/workers.py:224:56` `reportAttributeAccessIssue` Cannot access attribute "_persist_task_user_prompt" for class "WorkersMixin*"   Attribute "_persist_task_user_prompt" is unknown
+- `src/pbi_agent/web/session/workers.py:232:30` `reportAttributeAccessIssue` Cannot access attribute "_publish_persisted_user_message" for class "WorkersMixin*"   Attribute "_publish_persisted_user_message" is unknown
+- `src/pbi_agent/web/session/workers.py:250:41` `reportAttributeAccessIssue` Cannot access attribute "_workspace_root" for class "WorkersMixin*"   Attribute "_workspace_root" is unknown
+- `src/pbi_agent/web/session/workers.py:256:36` `reportAttributeAccessIssue` Cannot access attribute "_shutdown_interrupted_task_ids" for class "WorkersMixin*"   Attribute "_shutdown_interrupted_task_ids" is unknown
+- `src/pbi_agent/web/session/workers.py:257:50` `reportCallIssue` Expected 0 positional arguments
+- `src/pbi_agent/web/session/workers.py:261:26` `reportAttributeAccessIssue` Cannot access attribute "_bind_live_session" for class "WorkersMixin*"   Attribute "_bind_live_session" is unknown
+- `src/pbi_agent/web/session/workers.py:288:46` `reportAttributeAccessIssue` Cannot access attribute "_next_board_stage_id" for class "WorkersMixin*"   Attribute "_next_board_stage_id" is unknown
+- `src/pbi_agent/web/session/workers.py:301:37` `reportAttributeAccessIssue` Cannot access attribute "_should_auto_start_stage" for class "WorkersMixin*"   Attribute "_should_auto_start_stage" is unknown
+- `src/pbi_agent/web/session/workers.py:305:35` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:309:35` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:315:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_task_updated" for class "WorkersMixin*"   Attribute "_publish_task_updated" is unknown
+- `src/pbi_agent/web/session/workers.py:318:27` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:325:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_task_updated" for class "WorkersMixin*"   Attribute "_publish_task_updated" is unknown
+- `src/pbi_agent/web/session/workers.py:338:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "WorkersMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/workers.py:348:27` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:351:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_task_updated" for class "WorkersMixin*"   Attribute "_publish_task_updated" is unknown
+- `src/pbi_agent/web/session/workers.py:363:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "WorkersMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/workers.py:373:27` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:376:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_task_updated" for class "WorkersMixin*"   Attribute "_publish_task_updated" is unknown
+- `src/pbi_agent/web/session/workers.py:379:27` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:381:23` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:382:22` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "WorkersMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/workers.py:383:22` `reportAttributeAccessIssue` Cannot access attribute "_task_workers" for class "WorkersMixin*"   Attribute "_task_workers" is unknown
+- `src/pbi_agent/web/session/workers.py:387:24` `reportAttributeAccessIssue` Cannot access attribute "_lease_stop" for class "WorkersMixin*"   Attribute "_lease_stop" is unknown
+- `src/pbi_agent/web/session/workers.py:390:26` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "WorkersMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/workers.py:391:35` `reportAttributeAccessIssue` Cannot access attribute "_manager_owner_id" for class "WorkersMixin*"   Attribute "_manager_owner_id" is unknown
+- `src/pbi_agent/web/session/workers.py:400:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:401:38` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "WorkersMixin*"   Attribute "_live_sessions" is unknown
+- `src/pbi_agent/web/session/workers.py:415:26` `reportAttributeAccessIssue` Cannot access attribute "_shutdown_interrupted_task_ids" for class "WorkersMixin*"   Attribute "_shutdown_interrupted_task_ids" is unknown
+- `src/pbi_agent/web/session/workers.py:418:18` `reportAttributeAccessIssue` Cannot access attribute "_publish_live_event" for class "WorkersMixin*"   Attribute "_publish_live_event" is unknown
+- `src/pbi_agent/web/session/workers.py:428:23` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:442:22` `reportAttributeAccessIssue` Cannot access attribute "_publish_task_updated" for class "WorkersMixin*"   Attribute "_publish_task_updated" is unknown
+- `src/pbi_agent/web/session/workers.py:445:19` `reportAttributeAccessIssue` Cannot access attribute "_lock" for class "WorkersMixin*"   Attribute "_lock" is unknown
+- `src/pbi_agent/web/session/workers.py:448:21` `reportAttributeAccessIssue` Cannot access attribute "_running_task_ids" for class "WorkersMixin*"   Attribute "_running_task_ids" is unknown
+- `src/pbi_agent/web/session/workers.py:448:46` `reportAttributeAccessIssue` Cannot access attribute "_shutdown_interrupted_task_ids" for class "WorkersMixin*"   Attribute "_shutdown_interrupted_task_ids" is unknown
+- `src/pbi_agent/web/session/workers.py:455:18` `reportAttributeAccessIssue` Cannot access attribute "_lease_stop" for class "WorkersMixin*"   Attribute "_lease_stop" is unknown
+- `src/pbi_agent/web/session/workers.py:465:22` `reportAttributeAccessIssue` Cannot access attribute "_directory_key" for class "WorkersMixin*"   Attribute "_directory_key" is unknown
+- `src/pbi_agent/web/session/workers.py:466:31` `reportAttributeAccessIssue` Cannot access attribute "_manager_owner_id" for class "WorkersMixin*"   Attribute "_manager_owner_id" is unknown
+- `src/pbi_agent/web/session/workers.py:472:32` `reportAttributeAccessIssue` Cannot access attribute "_task_workers" for class "WorkersMixin*"   Attribute "_task_workers" is unknown
+- `src/pbi_agent/web/session/workers.py:477:33` `reportAttributeAccessIssue` Cannot access attribute "_live_sessions" for class "WorkersMixin*"   Attribute "_live_sessions" is unknown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,26 @@ markers = [
 ]
 addopts = "-q --tb=short -x"
 
+[tool.basedpyright]
+include = ["src"]
+exclude = [
+    "**/__pycache__",
+    ".venv",
+    "build",
+    "dist",
+    "node_modules",
+    "webapp",
+]
+pythonVersion = "3.12"
+typeCheckingMode = "basic"
+reportUnusedFunction = "error"
+reportUnusedClass = "error"
+reportUnusedVariable = "error"
+reportUnusedImport = "error"
+
 [dependency-groups]
 dev = [
+    "basedpyright==1.39.3",
     "httpx==0.28.1",
     "pytest==9.0.3",
     "pytest-asyncio>=1.3.0",

--- a/src/pbi_agent/agent/error_formatting.py
+++ b/src/pbi_agent/agent/error_formatting.py
@@ -241,15 +241,6 @@ def _extract_structured_error(message: str) -> _StructuredErrorInfo:
     )
 
 
-def _extract_error_detail(message: str) -> str:
-    payload = _parse_embedded_json(message)
-    if payload is None:
-        return message
-
-    extracted = _extract_from_payload(payload)
-    return extracted or message
-
-
 def _parse_embedded_json(message: str) -> dict[str, Any] | None:
     start = message.find("{")
     if start < 0:

--- a/src/pbi_agent/agent/session.py
+++ b/src/pbi_agent/agent/session.py
@@ -1357,12 +1357,6 @@ def _messages_for_provider_restore(
     return restored
 
 
-def _messages_for_compaction(
-    messages: list[MessageRecord],
-) -> list[MessageRecord]:
-    return _active_context_messages(messages)
-
-
 def _active_context_messages(
     messages: list[MessageRecord] | tuple[MessageRecord, ...],
 ) -> list[MessageRecord]:
@@ -1824,18 +1818,6 @@ def _format_tool_exchanges_for_compaction(
         )
     chunks.append("</current_turn_tool_exchanges>")
     return "\n".join(chunks)
-
-
-def _format_pending_tool_exchange_for_compaction(
-    pending_tool_calls: list[ToolCall] | None,
-    pending_tool_result_items: list[dict[str, Any]] | None,
-) -> str:
-    return _format_tool_exchanges_for_compaction(
-        _normalize_tool_exchanges_for_compaction(
-            pending_tool_calls=pending_tool_calls,
-            pending_tool_result_items=pending_tool_result_items,
-        )
-    )
 
 
 def _format_one_tool_exchange_for_compaction(

--- a/src/pbi_agent/cli/sandbox.py
+++ b/src/pbi_agent/cli/sandbox.py
@@ -286,7 +286,7 @@ def _sandbox_container_workspace(workspace: Path) -> str:
     return f"{SANDBOX_WORKSPACE}/{_sandbox_workspace_id(workspace)}"
 
 
-def _sandbox_config_volume(workspace: Path) -> str:
+def _sandbox_config_volume(workspace: Path) -> str:  # pyright: ignore[reportUnusedFunction] - imported by sandbox tests
     return f"{SANDBOX_CONFIG_VOLUME_PREFIX}-{_sandbox_workspace_id(workspace)}"
 
 

--- a/src/pbi_agent/providers/chatgpt_codex_backend.py
+++ b/src/pbi_agent/providers/chatgpt_codex_backend.py
@@ -547,16 +547,6 @@ def _read_http_upgrade_response(
     return status, headers, body_bytes
 
 
-def _recv_exact(sock: socket.socket, length: int) -> bytes:
-    data = b""
-    while len(data) < length:
-        chunk = sock.recv(length - len(data))
-        if not chunk:
-            raise ConnectionError("websocket closed")
-        data += chunk
-    return data
-
-
 def _json_object(text: str) -> dict[str, Any] | None:
     try:
         value = json.loads(text)

--- a/src/pbi_agent/tools/read_file.py
+++ b/src/pbi_agent/tools/read_file.py
@@ -488,13 +488,6 @@ def _read_xlsx_sheet_bounds(worksheet: Any) -> tuple[int, int]:
     return (max_row, max_column)
 
 
-def _excel_column_letters_to_index(letters: str) -> int:
-    index = 0
-    for character in letters:
-        index = index * 26 + (ord(character) - ord("A") + 1)
-    return index
-
-
 def _coerce_temporal_columns(dataframe: Any) -> Any:
     from pandas.api import types as ptypes
 

--- a/src/pbi_agent/web/app_factory.py
+++ b/src/pbi_agent/web/app_factory.py
@@ -82,19 +82,19 @@ def create_app(
         app.mount("/assets", StaticFiles(directory=str(assets_dir)), name="assets")
 
     @app.get("/favicon.ico")
-    def favicon_ico() -> FileResponse:
+    def favicon_ico() -> FileResponse:  # pyright: ignore[reportUnusedFunction] - FastAPI route handler
         return FileResponse(LOGO_PATH, media_type="image/jpeg")
 
     @app.get("/favicon.png")
-    def favicon_png() -> FileResponse:
+    def favicon_png() -> FileResponse:  # pyright: ignore[reportUnusedFunction] - FastAPI route handler
         return FileResponse(LOGO_PATH, media_type="image/jpeg")
 
     @app.get("/logo.png")
-    def logo() -> FileResponse:
+    def logo() -> FileResponse:  # pyright: ignore[reportUnusedFunction] - FastAPI route handler
         return FileResponse(LOGO_PATH, media_type="image/jpeg")
 
     @app.get("/logo.jpg")
-    def logo_jpg() -> FileResponse:
+    def logo_jpg() -> FileResponse:  # pyright: ignore[reportUnusedFunction] - FastAPI route handler
         return FileResponse(LOGO_PATH, media_type="image/jpeg")
 
     app.include_router(system_router)
@@ -105,11 +105,11 @@ def create_app(
     app.include_router(events_router)
 
     @app.get("/", response_class=HTMLResponse)
-    def index() -> Response:
+    def index() -> Response:  # pyright: ignore[reportUnusedFunction] - FastAPI route handler
         return spa_index_response(title or "pbi-agent")
 
     @app.get("/{full_path:path}", response_class=HTMLResponse)
-    def spa_fallback(full_path: str) -> Response:
+    def spa_fallback(full_path: str) -> Response:  # pyright: ignore[reportUnusedFunction] - FastAPI route handler
         if full_path.startswith("api/"):
             raise HTTPException(status_code=404, detail="Not found.")
         if full_path == APP_EVENT_STREAM_ID:

--- a/src/pbi_agent/web/session/serializers.py
+++ b/src/pbi_agent/web/session/serializers.py
@@ -93,7 +93,9 @@ def _run_status_from_run(record: RunSessionRecord) -> str:
     return "started"
 
 
-def _persisted_web_run_status(live_session: "LiveSessionState") -> str:
+def _persisted_web_run_status(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    live_session: "LiveSessionState",
+) -> str:
     if live_session.terminal_status is not None:
         return live_session.terminal_status
     if live_session.status == "ended":
@@ -105,7 +107,7 @@ def _persisted_web_run_status(live_session: "LiveSessionState") -> str:
     return live_session.status
 
 
-def _serialize_session(
+def _serialize_session(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
     record: SessionRecord,
     *,
     active_live_session: "LiveSessionState | None" = None,
@@ -148,7 +150,9 @@ def _serialize_session(
     }
 
 
-def _is_active_live_session(live_session: "LiveSessionState") -> bool:
+def _is_active_live_session(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    live_session: "LiveSessionState",
+) -> bool:
     return (
         live_session.status in _ACTIVE_LIVE_SESSION_STATUSES
         and live_session.ended_at is None
@@ -164,7 +168,9 @@ def _deserialize_json_field(raw_value: str | None) -> Any:
         return raw_value
 
 
-def _web_event_from_record(record: ObservabilityEventRecord) -> dict[str, Any] | None:
+def _web_event_from_record(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    record: ObservabilityEventRecord,
+) -> dict[str, Any] | None:
     if record.event_type != "web_event":
         return None
     metadata = _deserialize_json_field(record.metadata_json)
@@ -226,7 +232,7 @@ def _namespace_run_value(run_session_id: str, value: str) -> str:
     return f"{run_session_id}:{value}"
 
 
-def _combined_timeline_snapshot(
+def _combined_timeline_snapshot(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
     records: list[RunSessionRecord],
     current_snapshot: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
@@ -284,7 +290,9 @@ def _combined_timeline_snapshot(
     return latest
 
 
-def _format_shell_command_output(result: dict[str, Any] | str) -> str:
+def _format_shell_command_output(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    result: dict[str, Any] | str,
+) -> str:
     if not isinstance(result, dict):
         return f"## Shell command output\n\n```text\n{result}\n```"
     exit_code = result.get("exit_code")
@@ -304,11 +312,15 @@ def _format_shell_command_output(result: dict[str, Any] | str) -> str:
     return "\n".join(sections)
 
 
-def _session_title_for_input(text: str) -> str:
+def _session_title_for_input(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    text: str,
+) -> str:
     return text.strip()[:80]
 
 
-def _serialize_run_session(record: RunSessionRecord) -> dict[str, Any]:
+def _serialize_run_session(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    record: RunSessionRecord,
+) -> dict[str, Any]:
     return {
         "run_session_id": record.run_session_id,
         "session_id": record.session_id,
@@ -346,7 +358,9 @@ def _serialize_run_session(record: RunSessionRecord) -> dict[str, Any]:
     }
 
 
-def _serialize_run_as_live_session(record: RunSessionRecord) -> dict[str, Any]:
+def _serialize_run_as_live_session(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    record: RunSessionRecord,
+) -> dict[str, Any]:
     metadata = _deserialize_json_field(record.metadata_json)
     runtime = metadata.get("runtime") if isinstance(metadata, dict) else None
     runtime = runtime if isinstance(runtime, dict) else {}
@@ -373,7 +387,7 @@ def _serialize_run_as_live_session(record: RunSessionRecord) -> dict[str, Any]:
     }
 
 
-def _serialize_saved_session_runtime(
+def _serialize_saved_session_runtime(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
     record: SessionRecord,
     runtime: ResolvedRuntime,
 ) -> dict[str, Any]:
@@ -400,7 +414,9 @@ def _serialize_saved_session_runtime(
     }
 
 
-def _serialize_observability_event(record: ObservabilityEventRecord) -> dict[str, Any]:
+def _serialize_observability_event(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    record: ObservabilityEventRecord,
+) -> dict[str, Any]:
     return {
         "run_session_id": record.run_session_id,
         "session_id": record.session_id,
@@ -449,7 +465,9 @@ def _runtime_summary(runtime: ResolvedRuntime | None) -> dict[str, Any]:
     }
 
 
-def _resolved_runtime_view(runtime: ResolvedRuntime) -> dict[str, Any]:
+def _resolved_runtime_view(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    runtime: ResolvedRuntime,
+) -> dict[str, Any]:
     return {
         "provider": runtime.settings.provider,
         "provider_id": runtime.provider_id,
@@ -472,11 +490,13 @@ def _resolved_runtime_view(runtime: ResolvedRuntime) -> dict[str, Any]:
     }
 
 
-def _snapshot_item_id(item: dict[str, Any]) -> str:
+def _snapshot_item_id(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    item: dict[str, Any],
+) -> str:
     return str(item.get("itemId") or item.get("item_id") or "")
 
 
-def _serialize_task(
+def _serialize_task(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
     record: KanbanTaskRecord,
     *,
     runtime: ResolvedRuntime | None,
@@ -505,7 +525,9 @@ def _serialize_task(
     }
 
 
-def _serialize_board_stage(record: KanbanStageConfigRecord) -> dict[str, Any]:
+def _serialize_board_stage(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    record: KanbanStageConfigRecord,
+) -> dict[str, Any]:
     return {
         "id": record.stage_id,
         "name": record.name,
@@ -516,7 +538,9 @@ def _serialize_board_stage(record: KanbanStageConfigRecord) -> dict[str, Any]:
     }
 
 
-def _serialize_history_message(message: MessageRecord) -> dict[str, Any]:
+def _serialize_history_message(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    message: MessageRecord,
+) -> dict[str, Any]:
     return persisted_message_payload(message)
 
 
@@ -524,7 +548,9 @@ def _preview_url(upload_id: str) -> str:
     return f"/api/uploads/{upload_id}"
 
 
-def _message_image_attachment(record: StoredImageUpload) -> MessageImageAttachment:
+def _message_image_attachment(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    record: StoredImageUpload,
+) -> MessageImageAttachment:
     return MessageImageAttachment(
         upload_id=record.upload_id,
         name=record.name,
@@ -546,5 +572,7 @@ def _message_image_payload(
     }
 
 
-def _config_sort_key(name: str, item_id: str) -> tuple[str, str]:
+def _config_sort_key(  # pyright: ignore[reportUnusedFunction] - imported by session route modules
+    name: str, item_id: str
+) -> tuple[str, str]:
     return (name.lower(), item_id)

--- a/src/pbi_agent/web/session/workers.py
+++ b/src/pbi_agent/web/session/workers.py
@@ -176,15 +176,6 @@ class WorkersMixin:
         is_initial_worker_turn = initial_user_message_id is not None
         task_result_finalization_failed = False
 
-        def publish_summary(summary: str) -> None:
-            with SessionStore() as store:
-                updated = store.update_kanban_task(
-                    task_id,
-                    last_result_summary=summary,
-                )
-            if updated is not None:
-                self._publish_task_updated(updated)
-
         try:
             if live_session is not None:
                 live_session.status = "running"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 import json
 import os
 from pathlib import Path
-import urllib.error
 import urllib.request
 
 import pytest

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -926,9 +926,10 @@ def test_list_all_run_sessions_with_filters(tmp_path) -> None:
         assert total == 4
 
         # Filter by status
-        completed, total = store.list_all_run_sessions(
+        completed_runs, total = store.list_all_run_sessions(
             directory="/w", status="completed"
         )
+        assert len(completed_runs) == 2
         assert total == 2
 
         # Filter by provider

--- a/uv.lock
+++ b/uv.lock
@@ -158,6 +158,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.39.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/19/5a5b9b9197973da732638957be3a65cf514d2f5a4964eeedbf33b6c65bbd/basedpyright-1.39.3.tar.gz", hash = "sha256:2f794e6b5f4260fb89f614ca6cd23c6f305373bb6b50c4ed7794ff2ae647fb14", size = 25503187, upload-time = "2026-04-20T22:14:47.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/5c/f950c1239ad26f3bb453e665428a2cf1893995de725a5eb0b64a2520b366/basedpyright-1.39.3-py3-none-any.whl", hash = "sha256:aba760dc83307727554f936d6b4381caa14482f30dbc2173167710e217c1f7ab", size = 12419181, upload-time = "2026-04-20T22:14:51.975Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -766,6 +778,22 @@ wheels = [
 ]
 
 [[package]]
+name = "nodejs-wheel-binaries"
+version = "24.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/70/a1e4f4d5986768ab90cc860b1cc3660fd2ded74ca175a900a5c29f839c7d/nodejs_wheel_binaries-24.15.0.tar.gz", hash = "sha256:b43f5c4f6e5768d8845b2ae4682eb703a19bf7aadc84187e2d903ed3a611c859", size = 8057, upload-time = "2026-04-19T15:48:16.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/66/54051d14853d6ab4fb85f8be9b042b530be653357fb9a19557498bc91ab7/nodejs_wheel_binaries-24.15.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:a6232fa8b754220941f52388c8ead923f7c1c7fdf0ea0d98f657523bd9a81ef4", size = 55173485, upload-time = "2026-04-19T15:47:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5f/66acada164da5ca10a0824db021aa7394ae18396c550cd9280e839a43126/nodejs_wheel_binaries-24.15.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:001a6b62c69d9109c1738163cca00608dd2722e8663af59300054ea02610972d", size = 55348100, upload-time = "2026-04-19T15:47:40.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2d/0cbd5ff40c9bb030ca1735d8f8793bd74f08a4cbd49100a1d19313ea57ab/nodejs_wheel_binaries-24.15.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0fbc48765e60ed0ff30d43898dbf5cadbadf2e5f1e7f204afc2b01493b7ebce6", size = 59668206, upload-time = "2026-04-19T15:47:46.848Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d5/91ac63951ec75927a486b83b8cafe650e360fa70ac01dc94adfb32b93b97/nodejs_wheel_binaries-24.15.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:20ee0536809795da8a4942fc1ab4cbdebbcaaf29383eab67ba8874268fb00008", size = 60206736, upload-time = "2026-04-19T15:47:52.668Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/dc22776974d928869c0c30d23ee98ed7df254243c2df68f09f5963e8e8b8/nodejs_wheel_binaries-24.15.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1fade6c214285e72472ca40a631e98ff36559671cd5eefc8bf009471d67f04b4", size = 61720456, upload-time = "2026-04-19T15:47:58.325Z" },
+    { url = "https://files.pythonhosted.org/packages/01/0a/34461b9050cb45ee371dccdefc622aef6351506ea2691b08fc761ca67150/nodejs_wheel_binaries-24.15.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3984cb8d87766567aee67a49743227ab40ede6f47734ec990ff90e50b74e7740", size = 62326172, upload-time = "2026-04-19T15:48:04.094Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/09252bf35672dba926649d59dfe51443a0f6955ad13784e91131d5ec82a2/nodejs_wheel_binaries-24.15.0-py2.py3-none-win_amd64.whl", hash = "sha256:a437601956b532dcb3082046e6978e622733f90edc0932cbb9adb3bb97a16501", size = 41543461, upload-time = "2026-04-19T15:48:09.332Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/b649777d148e1e0c2ce349156603cdb12f7ed99921b95d93717393650193/nodejs_wheel_binaries-24.15.0-py2.py3-none-win_arm64.whl", hash = "sha256:bdf4a431e08321a32efc604111c6f23941f87055d796a537e8c4110daecad23f", size = 39233248, upload-time = "2026-04-19T15:48:13.326Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -937,6 +965,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -960,6 +989,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "basedpyright", specifier = ">=1.39.3" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },


### PR DESCRIPTION
## Summary
- Add BasedPyright as a dev dependency with project configuration.
- Document BasedPyright in agent command/workflow validation guidance.
- Clean up unused symbols and add a diagnostics analysis artifact for follow-up typing work.

## Local validation
- Passed: `uv run ruff check .`
- Passed: `uv run ruff format .`
- Passed: `uv run python scripts/dead_code.py`
- Passed: `uv run pytest -q --tb=short -x`
- Passed: `bun run test:web`
- Passed: `bun run lint`
- Passed: `bun run typecheck`
- Passed: `bun run web:build`
- Passed: `bun run docs:build`
- Skipped by user request: `uv run basedpyright`

## GitHub workflow checks
- Pending: will run `gh pr checks <pr> --watch --fail-fast --interval 10` before merge.

## Known unshipped or skipped changes
- Local `master` has an unrelated ahead memory-only commit not included in this PR.
- A temporary local stash from branch separation may remain until merge cleanup.