### PR TITLE
chore: release v0.3.1

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.3.1', link: '/changelog/v0.3.1' },
           { text: 'v0.3.0', link: '/changelog/v0.3.0' },
           { text: 'v0.2.0', link: '/changelog/v0.2.0' },
           { text: 'v0.1.0', link: '/changelog/v0.1.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.3.1 - 2026-05-07](./v0.3.1.md)
 - [v0.3.0 - 2026-05-07](./v0.3.0.md)
 - [v0.2.0 - 2026-05-05](./v0.2.0.md)
 - [v0.1.0 - 2026-04-30](./v0.1.0.md)

--- a/docs/changelog/v0.3.1.md
+++ b/docs/changelog/v0.3.1.md
@@ -1,0 +1,25 @@
+---
+title: v0.3.1
+description: Changelog for pbi-agent v0.3.1, released on 2026-05-07.
+---
+
+# v0.3.1
+
+**Release date:** 2026-05-07
+
+## Added
+
+- Bundled GitHub CLI in the sandbox image so sandboxed release and GitHub workflows can use `gh` without extra setup ([#271](https://github.com/pbi-agent/pbi-agent/pull/271)).
+
+## Changed
+
+- Improved sandbox workspace identity, local source testing, host Git configuration mounts, and bundled utility handling for a smoother container workflow ([#271](https://github.com/pbi-agent/pbi-agent/pull/271)).
+- Refactored the monolithic CLI into focused package modules while preserving the public CLI facade and command behavior ([#272](https://github.com/pbi-agent/pbi-agent/pull/272)).
+
+## Fixed
+
+- Hardened tool execution under thread exhaustion by retrying with fewer workers and falling back to serial execution when needed ([#271](https://github.com/pbi-agent/pbi-agent/pull/271)).
+
+## Documentation
+
+- Added release workflow guidance to verify GitHub Release body formatting and repair malformed notes before reporting publish success ([#270](https://github.com/pbi-agent/pbi-agent/pull/270)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.3.0"
+version = "0.3.1"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Release pbi-agent v0.3.1 with sandbox workflow improvements, GitHub CLI availability in sandbox, tool runtime hardening, and CLI package refactoring.
- Bump package metadata from 0.3.0 to 0.3.1 and add the v0.3.1 changelog page.

## Highlights
### Added
- Bundled GitHub CLI in the sandbox image so sandboxed release and GitHub workflows can use `gh` without extra setup ([#271](https://github.com/pbi-agent/pbi-agent/pull/271)).

### Changed
- Improved sandbox workspace identity, local source testing, host Git configuration mounts, and bundled utility handling for a smoother container workflow ([#271](https://github.com/pbi-agent/pbi-agent/pull/271)).
- Refactored the monolithic CLI into focused package modules while preserving the public CLI facade and command behavior ([#272](https://github.com/pbi-agent/pbi-agent/pull/272)).

### Fixed
- Hardened tool execution under thread exhaustion by retrying with fewer workers and falling back to serial execution when needed ([#271](https://github.com/pbi-agent/pbi-agent/pull/271)).

### Documentation
- Added release workflow guidance to verify GitHub Release body formatting and repair malformed notes before reporting publish success ([#270](https://github.com/pbi-agent/pbi-agent/pull/270)).

## Changelog
- `docs/changelog/v0.3.1.md`

## Validation
- [x] `uv run ruff check .` passed
- [x] `uv run ruff format --check .` passed
- [x] `uv run basedpyright` passed
- [x] `uv run python scripts/dead_code.py` passed
- [x] `uv run pytest -q --tb=short -x` passed
- [x] `bun run docs:build` passed

## Skipped, excluded, or unrelated changes
- Excluded session-local `TODO.md` workspace edits from the release commit.
