### PR TITLE
chore: release v0.4.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.4.0', link: '/changelog/v0.4.0' },
           { text: 'v0.3.1', link: '/changelog/v0.3.1' },
           { text: 'v0.3.0', link: '/changelog/v0.3.0' },
           { text: 'v0.2.0', link: '/changelog/v0.2.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.4.0 - 2026-05-09](./v0.4.0.md)
 - [v0.3.1 - 2026-05-07](./v0.3.1.md)
 - [v0.3.0 - 2026-05-07](./v0.3.0.md)
 - [v0.2.0 - 2026-05-05](./v0.2.0.md)

--- a/docs/changelog/v0.4.0.md
+++ b/docs/changelog/v0.4.0.md
@@ -1,0 +1,32 @@
+---
+title: v0.4.0
+description: Changelog for pbi-agent v0.4.0, released on 2026-05-09.
+---
+
+# v0.4.0
+
+**Release date:** 2026-05-09
+
+## Added
+
+- Added Settings → Project management for Skills, Commands, and Agents, including installed lists, official/custom catalog browsing, install flows, and replace-on-conflict support ([#283](https://github.com/pbi-agent/pbi-agent/pull/283)).
+- Added keyboard shortcuts to toggle interactive mode and open a new blank session from the web UI ([#283](https://github.com/pbi-agent/pbi-agent/pull/283)).
+- Added appearance/theme settings and compacted-session display refinements in the settings experience ([#278](https://github.com/pbi-agent/pbi-agent/pull/278)).
+
+## Changed
+
+- Refined the responsive web shell with a persistent collapsible sidebar, improved mobile sidebar behavior, and board layout fixes ([#277](https://github.com/pbi-agent/pbi-agent/pull/277)).
+- Polished sidebar hover states, tooltips, collapsed icons, run history, workspace badge alignment, model selector spacing, and session topbar actions ([#278](https://github.com/pbi-agent/pbi-agent/pull/278), [#283](https://github.com/pbi-agent/pbi-agent/pull/283)).
+- Hardened sandbox bootstrap and package setup, including mounted home tooling and GitHub CLI availability in sandbox workflows ([#279](https://github.com/pbi-agent/pbi-agent/pull/279)).
+
+## Fixed
+
+- Made local web test execution more stable by constraining Vitest worker usage to avoid timeout flakiness ([#277](https://github.com/pbi-agent/pbi-agent/pull/277)).
+
+## Documentation
+
+- Updated customization and sandbox documentation for the new project catalog management and sandbox bootstrap behavior ([#279](https://github.com/pbi-agent/pbi-agent/pull/279), [#283](https://github.com/pbi-agent/pbi-agent/pull/283)).
+
+## Internal
+
+- Regenerated API types and packaged web static assets for the web project catalog management changes ([#283](https://github.com/pbi-agent/pbi-agent/pull/283)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.3.1"
+version = "0.4.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Prepare pbi-agent v0.4.0 from merged PRs since v0.3.1. This release focuses on web project catalog management, web shell/sidebar polish, sandbox bootstrap hardening, and related documentation/static asset updates.

## Highlights

### Added
- Settings → Project management for Skills, Commands, and Agents with installed lists, official/custom catalog browsing, install flows, and replace-on-conflict support (#283).
- Web keyboard shortcuts for toggling interactive mode and opening a new blank session (#283).
- Appearance/theme settings and compacted-session display refinements (#278).

### Changed
- Refined the responsive web shell with a persistent collapsible sidebar, mobile sidebar behavior, and board layout fixes (#277).
- Polished sidebar hover states, tooltips, collapsed icons, run history, workspace badge alignment, model selector spacing, and session topbar actions (#278, #283).
- Hardened sandbox bootstrap/package setup, including mounted home tooling and GitHub CLI availability (#279).

### Fixed
- Stabilized local web test execution by constraining Vitest worker usage (#277).

### Documentation/Internal
- Updated customization and sandbox documentation, regenerated API types, and packaged web static assets for catalog-management changes (#279, #283).

## Changelog

- docs/changelog/v0.4.0.md

## Validation

Passed locally:

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright`
- `uv run python scripts/dead_code.py`
- `uv run pytest -q --tb=short -x`
- `bun run docs:build`

## Skipped, excluded, or unrelated changes

- Unstaged local `TODO.md` release bookkeeping is excluded from this PR.
- No unrelated source changes included.
