### PR TITLE
chore: release v0.5.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.5.0', link: '/changelog/v0.5.0' },
           { text: 'v0.4.0', link: '/changelog/v0.4.0' },
           { text: 'v0.3.1', link: '/changelog/v0.3.1' },
           { text: 'v0.3.0', link: '/changelog/v0.3.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.5.0 - 2026-05-10](./v0.5.0.md)
 - [v0.4.0 - 2026-05-09](./v0.4.0.md)
 - [v0.3.1 - 2026-05-07](./v0.3.1.md)
 - [v0.3.0 - 2026-05-07](./v0.3.0.md)

--- a/docs/changelog/v0.5.0.md
+++ b/docs/changelog/v0.5.0.md
@@ -1,0 +1,32 @@
+---
+title: v0.5.0
+description: Changelog for pbi-agent v0.5.0, released on 2026-05-10.
+---
+
+# v0.5.0
+
+**Release date:** 2026-05-10
+
+## Added
+
+- Added saved-session conversation forking from assistant turns, including forked upload copies for image messages ([#285](https://github.com/pbi-agent/pbi-agent/pull/285)).
+- Added hover copy shortcuts for user and assistant turns, plus snippet copy for code, tables, blockquotes, and lists with copied/failed feedback ([#285](https://github.com/pbi-agent/pbi-agent/pull/285)).
+- Added `/create-task` to create Kanban cards from chat without implementing them immediately ([#285](https://github.com/pbi-agent/pbi-agent/pull/285)).
+
+## Changed
+
+- Improved session timeline rendering with language-aware fenced code blocks, a clearer collapsed workspace badge, and visible sub-agent context usage ([#285](https://github.com/pbi-agent/pbi-agent/pull/285)).
+- Hardened direct chat command input state and adjusted shell timeout defaults for web-session workflows ([#285](https://github.com/pbi-agent/pbi-agent/pull/285)).
+
+## Fixed
+
+- Stabilized stale and restarted web sessions so old runs do not leave active Working state, stale live snapshots, or missing-run errors after restart ([#285](https://github.com/pbi-agent/pbi-agent/pull/285)).
+- Kept the Working shimmer stable during in-turn tool updates and fixed collapsed Working summaries to classify read, search, shell, edit, sub-agent, question, and other tool activity ([#285](https://github.com/pbi-agent/pbi-agent/pull/285)).
+
+## Documentation
+
+- Documented the Kanban task creation command and refreshed settings modal form guidance ([#285](https://github.com/pbi-agent/pbi-agent/pull/285)).
+
+## Internal
+
+- Rebuilt packaged web assets for the shipped web-session UX fixes ([#285](https://github.com/pbi-agent/pbi-agent/pull/285)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.4.0"
+version = "0.5.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Prepare pbi-agent v0.5.0 from the merged web-session UX and workflow updates in #285.

## Highlights
### Added
- Saved-session conversation forking from assistant turns, including fork-safe image uploads.
- Hover copy shortcuts for user and assistant turns, plus snippet copy for code, tables, blockquotes, and lists.
- `/create-task` for creating Kanban cards from chat without immediately implementing them.

### Changed
- Improved session timeline rendering with language-aware fenced code blocks, collapsed workspace context, visible sub-agent usage, hardened direct command input state, and adjusted shell timeout defaults.

### Fixed
- Stabilized stale/restarted web sessions, Working shimmer state, and collapsed Working summary tool categorization.

### Documentation/Internal
- Updated Kanban command and settings form guidance.
- Bumped package metadata and lockfile to v0.5.0.

## Changelog
- docs/changelog/v0.5.0.md

## Validation
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run basedpyright`
- [x] `uv run python scripts/dead_code.py`
- [x] `uv run pytest -q --tb=short -x`
- [x] `bun run docs:build`
- [x] `git diff --check`

## Skipped or unrelated changes
- Excluded local task bookkeeping changes in `TODO.md` from this release commit.
