### PR TITLE
Add Node runtime packages to sandbox image

### DIFF
--- a/src/pbi_agent/sandbox/Dockerfile.sandbox
+++ b/src/pbi_agent/sandbox/Dockerfile.sandbox
@@ -4,7 +4,7 @@ ARG PYTHON_VERSION=3.12.12
 FROM python:${PYTHON_VERSION}-alpine3.22
 
 ARG PBI_AGENT_VERSION
-ARG RUNTIME_APK="bash ca-certificates curl git github-cli libstdc++ patch ripgrep unzip"
+ARG RUNTIME_APK="bash ca-certificates curl git github-cli libstdc++ patch ripgrep unzip nodejs npm"
 ARG EXTRA_APK=""
 ARG FLEXIBLE_SYSTEM_INSTALL=0
 ARG FLEX_APK="doas"

--- a/tests/cli/test_sandbox.py
+++ b/tests/cli/test_sandbox.py
@@ -617,7 +617,7 @@ class DefaultWebCommandTests(unittest.TestCase):
         content = dockerfile.read_text(encoding="utf-8")
         self.assertIn("FROM python:${PYTHON_VERSION}-alpine3.22", content)
         self.assertIn(
-            'ARG RUNTIME_APK="bash ca-certificates curl git github-cli libstdc++ patch ripgrep unzip"',
+            'ARG RUNTIME_APK="bash ca-certificates curl git github-cli libstdc++ patch ripgrep unzip nodejs npm"',
             content,
         )
         self.assertIn('ARG EXTRA_APK=""', content)


### PR DESCRIPTION
## Summary
- Add `nodejs` and `npm` to the sandbox runtime APK package list.
- Update the sandbox Dockerfile assertion to match the runtime package set.

## Local validation
- `uv run ruff check .` passed
- `uv run ruff format .` passed
- `uv run basedpyright` passed
- `uv run python scripts/dead_code.py` passed
- `uv run pytest -q --tb=short -x` passed on isolated task branch
- `bun run test:web` initially hit an unrelated cleanup hook timeout, rerun passed
- `bun run lint` passed
- `bun run typecheck` passed
- `bun run web:build` passed

## GitHub workflow checks
- Pending: will verify with `gh pr checks --watch --fail-fast --interval 10` before merge.

## Unshipped/skipped changes
- Local `master` remains ahead of `origin/master` with pre-existing unrelated commits; this PR was cherry-picked onto `origin/master` to ship only this task.