### PR TITLE
chore: release v0.6.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.6.0', link: '/changelog/v0.6.0' },
           { text: 'v0.5.0', link: '/changelog/v0.5.0' },
           { text: 'v0.4.0', link: '/changelog/v0.4.0' },
           { text: 'v0.3.1', link: '/changelog/v0.3.1' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.6.0 - 2026-05-10](./v0.6.0.md)
 - [v0.5.0 - 2026-05-10](./v0.5.0.md)
 - [v0.4.0 - 2026-05-09](./v0.4.0.md)
 - [v0.3.1 - 2026-05-07](./v0.3.1.md)

--- a/docs/changelog/v0.6.0.md
+++ b/docs/changelog/v0.6.0.md
@@ -1,0 +1,36 @@
+---
+title: v0.6.0
+description: Changelog for pbi-agent v0.6.0, released on 2026-05-10.
+---
+
+# v0.6.0
+
+**Release date:** 2026-05-10
+
+## Added
+
+- Added Node.js and npm to the sandbox runtime image so workspace tasks can run JavaScript tooling inside the sandbox ([#287](https://github.com/pbi-agent/pbi-agent/pull/287)).
+- Added a `check-confidence` command for confidence review handoffs ([835ec12](https://github.com/pbi-agent/pbi-agent/commit/835ec12)).
+- Added project sub-agent model profile metadata and Settings indicators so delegated agents can use configured saved profiles ([65dd03b](https://github.com/pbi-agent/pbi-agent/commit/65dd03b)).
+- Added Settings preview dialogs for installed skills and agents ([dd6e600](https://github.com/pbi-agent/pbi-agent/commit/dd6e600)).
+- Added gitignore-aware workspace file mention scanning, scan-state reporting, and Composer file suggestion UX ([c4b0ed6](https://github.com/pbi-agent/pbi-agent/commit/c4b0ed6)).
+- Added `$skill` tag completions and validated skill/file highlighting in chat timelines and Composer input ([438f3e4](https://github.com/pbi-agent/pbi-agent/commit/438f3e4)).
+
+## Changed
+
+- Converted `create-task` from a slash command into a project skill for task-card creation workflows ([e82a30b](https://github.com/pbi-agent/pbi-agent/commit/e82a30b)).
+- Normalized command frontmatter and override handling for project command catalogs ([c34d872](https://github.com/pbi-agent/pbi-agent/commit/c34d872)).
+- Renamed and compressed local project sub-agents while preserving orchestrated plan/review/fix/commit behavior ([b99aea9](https://github.com/pbi-agent/pbi-agent/commit/b99aea9), [4bb6635](https://github.com/pbi-agent/pbi-agent/commit/4bb6635)).
+- Refined mention highlight styling and orchestrate command documentation for clearer web and local workflows ([533e60b](https://github.com/pbi-agent/pbi-agent/commit/533e60b), [d344b1e](https://github.com/pbi-agent/pbi-agent/commit/d344b1e)).
+
+## Fixed
+
+- Fixed ask-user panel autofocus and separator styling so suggestion navigation works immediately ([a339399](https://github.com/pbi-agent/pbi-agent/commit/a339399)).
+- Fixed validated skill chip lookup limits for larger skill catalogs ([24882fc](https://github.com/pbi-agent/pbi-agent/commit/24882fc)).
+- Centered the Composer interrupt/send tooltip target ([8554853](https://github.com/pbi-agent/pbi-agent/commit/8554853)).
+- Fixed file highlight scan retry behavior while the workspace index is still scanning ([d991ae9](https://github.com/pbi-agent/pbi-agent/commit/d991ae9)).
+- Replaced a deprecated Composer submit event type with the supported React event type ([a3b6055](https://github.com/pbi-agent/pbi-agent/commit/a3b6055)).
+
+## Internal
+
+- Refactored supporting code and cleaned release/orchestration bookkeeping without changing user-facing behavior ([a3b71dd](https://github.com/pbi-agent/pbi-agent/commit/a3b71dd), [2b59a6b](https://github.com/pbi-agent/pbi-agent/commit/2b59a6b)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.5.0"
+version = "0.6.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/tests/cli/test_catalogs.py
+++ b/tests/cli/test_catalogs.py
@@ -172,6 +172,10 @@ class DefaultWebCommandTests(unittest.TestCase):
             commands_dir = root_dir / ".agents" / "commands"
             commands_dir.mkdir(parents=True)
             (commands_dir / "execute.md").write_text(
+                "---\n"
+                "name: execute\n"
+                "description: Run the task end-to-end.\n"
+                "---\n\n"
                 "# Execute\n\nRun the task end-to-end.\n",
                 encoding="utf-8",
             )

--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Prepare pbi-agent v0.6.0 for release with the version bump, changelog page, changelog index/sidebar updates, and the catalog test repair needed to keep release validation green.

## Highlights

### Added
- Node.js and npm are now available in the sandbox runtime image.
- Added confidence-review handoff support and sub-agent profile metadata in Settings.
- Added Settings preview dialogs for installed skills and agents.
- Added gitignore-aware workspace file mention scanning, scan-state UI, and validated skill/file highlighting.

### Changed
- Converted `create-task` into a project skill.
- Normalized command frontmatter and project command override handling.
- Renamed/compressed local project sub-agents and refined workflow documentation.

### Fixed
- Fixed ask-user autofocus/separator behavior, skill lookup limits, Composer tooltip alignment, file highlight scan retries, and a deprecated React event type.
- Repaired the CLI command catalog test fixture so project-command validation reflects the required frontmatter format.

## Changelog

- `docs/changelog/v0.6.0.md`

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run basedpyright`
- [x] `uv run python scripts/dead_code.py`
- [x] `uv run pytest -q --tb=short -x`
- [x] `bun run docs:build`

## Skipped or unrelated changes

- `MEMORY.md` and `TODO.md` are local session bookkeeping and are not included in this PR.
