### PR TITLE
chore: release v0.7.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.7.0', link: '/changelog/v0.7.0' },
           { text: 'v0.6.0', link: '/changelog/v0.6.0' },
           { text: 'v0.5.0', link: '/changelog/v0.5.0' },
           { text: 'v0.4.0', link: '/changelog/v0.4.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.7.0 - 2026-05-10](./v0.7.0.md)
 - [v0.6.0 - 2026-05-10](./v0.6.0.md)
 - [v0.5.0 - 2026-05-10](./v0.5.0.md)
 - [v0.4.0 - 2026-05-09](./v0.4.0.md)

--- a/docs/changelog/v0.7.0.md
+++ b/docs/changelog/v0.7.0.md
@@ -1,0 +1,16 @@
+---
+title: v0.7.0
+description: Changelog for pbi-agent v0.7.0, released on 2026-05-10.
+---
+
+# v0.7.0
+
+**Release date:** 2026-05-10
+
+## Added
+
+- Added ArrowUp/ArrowDown chat input history recall in session Composer inputs so users can resend or edit earlier messages from the current conversation ([#289](https://github.com/pbi-agent/pbi-agent/pull/289)).
+
+## Internal
+
+- Refreshed generated web assets and release bookkeeping included with the chat input history update ([#289](https://github.com/pbi-agent/pbi-agent/pull/289)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.6.0"
+version = "0.7.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Release v0.7.0 for the chat input history recall update merged after v0.6.0.
- Bump package metadata to 0.7.0 and add the per-release changelog page/sidebar entry.

## Highlights
### Added
- ArrowUp/ArrowDown chat input history recall in session Composer inputs so users can resend or edit earlier messages from the current conversation.

### Internal
- Refreshed release metadata and generated web asset bookkeeping from the shipped chat input history update.

## Changelog
- docs/changelog/v0.7.0.md

## Validation
- `uv run ruff check .` passed
- `uv run ruff format --check .` passed
- `uv run basedpyright` passed
- `uv run python scripts/dead_code.py` passed
- `uv run pytest -q --tb=short -x` passed
- `bun run docs:build` passed

## Skipped or unrelated changes
- Local `TODO.md` bookkeeping remains unstaged and excluded.
