### PR TITLE
chore: release v0.8.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.8.0', link: '/changelog/v0.8.0' },
           { text: 'v0.7.0', link: '/changelog/v0.7.0' },
           { text: 'v0.6.0', link: '/changelog/v0.6.0' },
           { text: 'v0.5.0', link: '/changelog/v0.5.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.8.0 - 2026-05-13](./v0.8.0.md)
 - [v0.7.0 - 2026-05-10](./v0.7.0.md)
 - [v0.6.0 - 2026-05-10](./v0.6.0.md)
 - [v0.5.0 - 2026-05-10](./v0.5.0.md)

--- a/docs/changelog/v0.8.0.md
+++ b/docs/changelog/v0.8.0.md
@@ -1,0 +1,28 @@
+---
+title: v0.8.0
+description: Changelog for pbi-agent v0.8.0, released on 2026-05-13.
+---
+
+# v0.8.0
+
+**Release date:** 2026-05-13
+
+## Added
+
+- Added Run Detail payload-card copy shortcuts with hover/focus affordances and copied/failed feedback ([#296](https://github.com/pbi-agent/pbi-agent/pull/296)).
+
+## Changed
+
+- Reordered Settings navigation around Models, Project, Desktop, and Data sections, with Providers opening by default ([#296](https://github.com/pbi-agent/pbi-agent/pull/296)).
+- Improved Settings and Run History responsive layouts, including the fixed scrolling Settings sidebar and dropdown behavior on narrow screens ([#296](https://github.com/pbi-agent/pbi-agent/pull/296)).
+- Polished Run Detail status styling by removing repeated model/status-code chips from event rows while preserving meaningful ok/fail state ([#296](https://github.com/pbi-agent/pbi-agent/pull/296)).
+- Refined session timeline behavior for replayed comments, image-input autoscroll, and expanded working-item guide styling ([#296](https://github.com/pbi-agent/pbi-agent/pull/296)).
+
+## Fixed
+
+- Fixed ChatGPT shell tool schema handling and aligned `apply_patch` behavior with Codex-style custom tool calls ([#296](https://github.com/pbi-agent/pbi-agent/pull/296)).
+- Fixed maintenance tab and install-conflict action button styling in Settings ([#296](https://github.com/pbi-agent/pbi-agent/pull/296)).
+
+## Internal
+
+- Added regression coverage and refreshed generated web assets for the UI and tool-runtime changes ([#296](https://github.com/pbi-agent/pbi-agent/pull/296)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.7.0"
+version = "0.8.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Release v0.8.0 for the merged local UI/tool updates from #296.

## Highlights
### Added
- Run Detail payload-card copy shortcuts with hover/focus affordances and copied/failed feedback.

### Changed
- Reordered Settings navigation around Models, Project, Desktop, and Data sections, with Providers opening by default.
- Improved Settings, Run History, Run Detail, and session timeline UI behavior and responsive polish.

### Fixed
- Fixed ChatGPT shell schema handling and aligned apply_patch behavior with Codex-style custom tool calls.
- Fixed Settings maintenance/install-conflict action styling.

## Changelog
- `docs/changelog/v0.8.0.md`

## Validation
- `bun run docs:build` ✅
- Prior full validation for release content in #296 ✅:
  - `uv run ruff check .`
  - `uv run ruff format .`
  - `uv run basedpyright`
  - `uv run python scripts/dead_code.py`
  - `uv run pytest -q --tb=short -x`
  - `bun run test:web`
  - `bun run lint`
  - `bun run typecheck`
  - `bun run web:build`
  - `bun run docs:build`

## Skipped / excluded
- Per publish instruction, full local test suite was not rerun for this release-only PR; GitHub PR checks will be used before merge.
- Unrelated local `TODO.md` changes are not included.
