### PR TITLE
chore: release v0.9.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.9.0', link: '/changelog/v0.9.0' },
           { text: 'v0.8.0', link: '/changelog/v0.8.0' },
           { text: 'v0.7.0', link: '/changelog/v0.7.0' },
           { text: 'v0.6.0', link: '/changelog/v0.6.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.9.0 - 2026-05-15](./v0.9.0.md)
 - [v0.8.0 - 2026-05-13](./v0.8.0.md)
 - [v0.7.0 - 2026-05-10](./v0.7.0.md)
 - [v0.6.0 - 2026-05-10](./v0.6.0.md)

--- a/docs/changelog/v0.9.0.md
+++ b/docs/changelog/v0.9.0.md
@@ -1,0 +1,33 @@
+---
+title: v0.9.0
+description: Changelog for pbi-agent v0.9.0, released on 2026-05-15.
+---
+
+# v0.9.0
+
+**Release date:** 2026-05-15
+
+## Added
+
+- Added a `/refine-task` project command for clarifying draft tasks without starting implementation ([#298](https://github.com/pbi-agent/pbi-agent/pull/298)).
+- Added dashboard-wide run filter values so dashboard filters reflect all matching runs, not only the current page ([#298](https://github.com/pbi-agent/pbi-agent/pull/298)).
+- Added configured reasoning effort to Run Detail headers and run-session API payloads ([c1e6947](https://github.com/pbi-agent/pbi-agent/commit/c1e6947)).
+
+## Changed
+
+- Refined session Working summaries with shared summary rendering, clearer formatting, and improved expansion behavior ([#298](https://github.com/pbi-agent/pbi-agent/pull/298)).
+- Centered the web startup update warning while preserving immediate CLI warning output for non-web commands ([#298](https://github.com/pbi-agent/pbi-agent/pull/298)).
+
+## Fixed
+
+- Fixed per-turn summary cost persistence and hydration for live and saved session timelines ([#298](https://github.com/pbi-agent/pbi-agent/pull/298)).
+- Fixed dashboard run filter dropdown values by sourcing distinct statuses, providers, and models from all scoped runs ([#298](https://github.com/pbi-agent/pbi-agent/pull/298)).
+
+## Documentation
+
+- Compressed the `/refine-task` command instructions while preserving its behavior and output template ([#298](https://github.com/pbi-agent/pbi-agent/pull/298)).
+
+## Internal
+
+- Refactored model catalog pricing entries into a clearer expanded structure without changing pricing data ([#298](https://github.com/pbi-agent/pbi-agent/pull/298)).
+- Refreshed generated API types, bundled web assets, and regression coverage for the dashboard, timeline, and Run Detail changes ([#298](https://github.com/pbi-agent/pbi-agent/pull/298), [c1e6947](https://github.com/pbi-agent/pbi-agent/commit/c1e6947)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.8.0"
+version = "0.9.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -957,7 +957,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Release pbi-agent v0.9.0 from changes merged since v0.8.0.
- Bump project metadata and lockfile version from 0.8.0 to 0.9.0.
- Add the v0.9.0 changelog page and link it from the changelog index and docs sidebar.

## Highlights

### Added
- Added a `/refine-task` project command for clarifying draft tasks without starting implementation.
- Added dashboard-wide run filter values so filters reflect all matching runs, not only the current page.
- Added configured reasoning effort to Run Detail headers and run-session API payloads.

### Changed
- Refined session Working summaries with shared summary rendering, clearer formatting, and improved expansion behavior.
- Centered the web startup update warning while preserving immediate CLI warning output for non-web commands.

### Fixed
- Fixed per-turn summary cost persistence and hydration for live and saved session timelines.
- Fixed dashboard run filter dropdown values by sourcing distinct statuses, providers, and models from all scoped runs.

### Documentation
- Compressed the `/refine-task` command instructions while preserving its behavior and output template.

### Internal
- Refactored model catalog pricing entries into a clearer expanded structure without changing pricing data.
- Refreshed generated API types, bundled web assets, and regression coverage for the dashboard, timeline, and Run Detail changes.

## Changelog
- docs/changelog/v0.9.0.md

## Validation
- [x] `uv run ruff check .` — passed
- [x] `uv run ruff format --check .` — passed
- [x] `uv run basedpyright` — passed
- [x] `uv run python scripts/dead_code.py` — passed
- [x] `uv run pytest -q --tb=short -x` — passed
- [x] `bun run docs:build` — passed

## Skipped or excluded changes
- Session `TODO.md` bookkeeping was intentionally not included in this release commit.
