### PR TITLE
Clarify TODO.md task-list formatting in AGENTS templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,9 @@ uv tool install --reinstall .
 
 - Use `TODO.md` for the current task session only.
 - Create or reset `TODO.md` before starting substantive work.
-- Use compact TODO markers: `[ ]` pending, `[>]` in progress, `[X]` done, `[!]` blocked, `[-]` dropped.
+- Use GitHub task-list bullets for every TODO entry: `- [ ]` pending, `- [>]` in progress, `- [x]` done, `- [!]` blocked, `- [-]` dropped.
 - Update `TODO.md` as you work. Mark steps complete when they finish, and revise the list when scope changes.
-- If TODO.md contains a completed task list, reset it before adding new changes. If it contains an unfinished list, append the new task instead.
+- If TODO.md contains a completed task list, reset it before adding new changes. If it contains an unfinished list, append new `- [ ] ...` tasks instead of writing plain paragraphs.
 
 ## Command Output
 

--- a/src/pbi_agent/init_agents.py
+++ b/src/pbi_agent/init_agents.py
@@ -30,9 +30,9 @@ when project workflows change.
 
 - Use `TODO.md` for the current task session only.
 - Create or reset `TODO.md` before starting substantive work.
-- Use compact TODO markers: `[ ]` pending, `[>]` in progress, `[X]` done, `[!]` blocked, `[-]` dropped.
+- Use GitHub task-list bullets for every TODO entry: `- [ ]` pending, `- [>]` in progress, `- [x]` done, `- [!]` blocked, `- [-]` dropped.
 - Update `TODO.md` as you work. Mark steps complete when they finish, and revise the list when scope changes.
-- If TODO.md contains a completed task list, reset it before adding new changes. If it contains an unfinished list, append the new task instead.
+- If TODO.md contains a completed task list, reset it before adding new changes. If it contains an unfinished list, append new `- [ ] ...` tasks instead of writing plain paragraphs.
 
 ## Command Output
 


### PR DESCRIPTION
### Motivation

- Ensure task lists written to `TODO.md` render as GitHub checklists instead of a single wrapped paragraph by requiring GitHub task-list bullet syntax.

### Description

- Update project guidance in `AGENTS.md` and the `AGENTS_TEMPLATE` in `src/pbi_agent/init_agents.py` to recommend explicit GitHub task-list bullets (`- [ ]`, `- [x]`, etc.) and to instruct appending unfinished tasks as `- [ ] ...` items.

### Testing

- No automated tests were run because this is a documentation/template-only change; the update was inspected in-place and limited to two files (`AGENTS.md` and `src/pbi_agent/init_agents.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1592d964a083259d6972276eebda7e)