### PR TITLE
chore: release v0.11.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -145,6 +145,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.11.0', link: '/changelog/v0.11.0' },
           { text: 'v0.10.0', link: '/changelog/v0.10.0' },
           { text: 'v0.9.2', link: '/changelog/v0.9.2' },
           { text: 'v0.9.1', link: '/changelog/v0.9.1' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.11.0 - 2026-05-29](./v0.11.0.md)
 - [v0.10.0 - 2026-05-17](./v0.10.0.md)
 - [v0.9.2 - 2026-05-17](./v0.9.2.md)
 - [v0.9.1 - 2026-05-17](./v0.9.1.md)

--- a/docs/changelog/v0.11.0.md
+++ b/docs/changelog/v0.11.0.md
@@ -1,0 +1,50 @@
+---
+title: v0.11.0
+description: Changelog for pbi-agent v0.11.0, released on 2026-05-29.
+---
+
+# v0.11.0
+
+**Release date:** 2026-05-29
+
+## Added
+
+- Added project Python extensions for custom slash-command workflows and documented extension setup ([ce116845](https://github.com/pbi-agent/pbi-agent/commit/ce116845)).
+- Added configurable tool visibility across CLI/model profiles/web, command and sub-agent frontmatter, and command-only `ask-user` support ([b27edaf3](https://github.com/pbi-agent/pbi-agent/commit/b27edaf3), [28ea6587](https://github.com/pbi-agent/pbi-agent/commit/28ea6587), [602a4a1a](https://github.com/pbi-agent/pbi-agent/commit/602a4a1a)).
+- Added workspace switching, WSL folder picking, and a git-aware Workspace Explorer with icons, file previews, diffs, changed-only filtering, and gitignore-aware scans ([02fa5a41](https://github.com/pbi-agent/pbi-agent/commit/02fa5a41), [49c0dffc](https://github.com/pbi-agent/pbi-agent/commit/49c0dffc), [62178ad5](https://github.com/pbi-agent/pbi-agent/commit/62178ad5), [6419332e](https://github.com/pbi-agent/pbi-agent/commit/6419332e)).
+- Added session history search and shared sidebar search styling for session/workspace panels ([cfbc618e](https://github.com/pbi-agent/pbi-agent/commit/cfbc618e), [9d68bc65](https://github.com/pbi-agent/pbi-agent/commit/9d68bc65)).
+- Added project skill and agent enablement controls, disabled-state handling, installed-agent metadata, and tags ([82fef30c](https://github.com/pbi-agent/pbi-agent/commit/82fef30c), [1e4a531d](https://github.com/pbi-agent/pbi-agent/commit/1e4a531d)).
+- Added `--include-history` support so runs can carry prior tool calls and results forward ([8f7fdb21](https://github.com/pbi-agent/pbi-agent/commit/8f7fdb21)).
+- Added Anthropic Claude Opus 4.8 model metadata and pricing details ([9fd7c44d](https://github.com/pbi-agent/pbi-agent/commit/9fd7c44d)).
+- Added executable temp-mount support to sandbox containers ([270db5b8](https://github.com/pbi-agent/pbi-agent/commit/270db5b8)).
+
+## Changed
+
+- Reworked built-in tool availability around the consolidated `explore_workspace` tool, profile/tool groups, and generated tool prompts ([3294ef21](https://github.com/pbi-agent/pbi-agent/commit/3294ef21), [568f28ad](https://github.com/pbi-agent/pbi-agent/commit/568f28ad), [b27edaf3](https://github.com/pbi-agent/pbi-agent/commit/b27edaf3)).
+- Refactored the agent session runtime into focused modules and stabilized sub-agent turn summaries and parent/child working activity ([63582085](https://github.com/pbi-agent/pbi-agent/commit/63582085), [ea20eabf](https://github.com/pbi-agent/pbi-agent/commit/ea20eabf)).
+- Refined web session topbar controls, run-history/usage presentation, Workspace Explorer shortcuts, settings catalog presentation, and command UI structure ([3aca8446](https://github.com/pbi-agent/pbi-agent/commit/3aca8446), [54a7d1f9](https://github.com/pbi-agent/pbi-agent/commit/54a7d1f9)).
+- Enforced strict model profiles and allowed tool groups in local command and sub-agent definitions, and clarified `TODO.md` task-list formatting in starter instructions ([df7de95e](https://github.com/pbi-agent/pbi-agent/commit/df7de95e), [#307](https://github.com/pbi-agent/pbi-agent/pull/307)).
+- Simplified sub-agent instructions and updated reviewer/fixer/planner agent definitions for the current tool model ([de67965b](https://github.com/pbi-agent/pbi-agent/commit/de67965b)).
+
+## Fixed
+
+- Fixed file-root reads and absolute-path handling in `explore_workspace` while preserving workspace confinement ([fae616a9](https://github.com/pbi-agent/pbi-agent/commit/fae616a9), [b9a8ec38](https://github.com/pbi-agent/pbi-agent/commit/b9a8ec38)).
+- Fixed incomplete tool-history replay, include-history behavior, sub-agent activity state, and session topbar wrapping ([47b892aa](https://github.com/pbi-agent/pbi-agent/commit/47b892aa), [0e58742a](https://github.com/pbi-agent/pbi-agent/commit/0e58742a), [97883527](https://github.com/pbi-agent/pbi-agent/commit/97883527), [9917a2a6](https://github.com/pbi-agent/pbi-agent/commit/9917a2a6)).
+- Fixed nondeterministic generated static app assets by aliasing duplicate Material Icon Theme SVGs ([96e0f94e](https://github.com/pbi-agent/pbi-agent/commit/96e0f94e)).
+- Fixed `fix-review` to use the reviewer profile and corrected command `allowed_tools` formatting ([a340bd3a](https://github.com/pbi-agent/pbi-agent/commit/a340bd3a), [42ff348e](https://github.com/pbi-agent/pbi-agent/commit/42ff348e)).
+- Allowed Kanban workers to advance after recoverable tool errors ([8e230fed](https://github.com/pbi-agent/pbi-agent/commit/8e230fed)).
+- Bumped `idna` from 3.13 to 3.15 ([#305](https://github.com/pbi-agent/pbi-agent/pull/305)).
+
+## Removed
+
+- Removed legacy tool and prompt assumptions in favor of `explore_workspace` and active tool-spec driven prompts ([c9926757](https://github.com/pbi-agent/pbi-agent/commit/c9926757), [568f28ad](https://github.com/pbi-agent/pbi-agent/commit/568f28ad)).
+- Removed project settings notification cards and moved installed catalog metadata into preview headers ([b31104b7](https://github.com/pbi-agent/pbi-agent/commit/b31104b7), [75a4c7e6](https://github.com/pbi-agent/pbi-agent/commit/75a4c7e6)).
+
+## Documentation
+
+- Reorganized customization documentation into dedicated pages for instructions, project rules, skills, commands, sub-agents, reload, MCP, and file constraints ([83ff184b](https://github.com/pbi-agent/pbi-agent/commit/83ff184b)).
+- Expanded docs for Python extensions, tool availability, model profiles, CLI/session commands, sandbox behavior, and Workspace Explorer usage ([ce116845](https://github.com/pbi-agent/pbi-agent/commit/ce116845), [b27edaf3](https://github.com/pbi-agent/pbi-agent/commit/b27edaf3), [6c21e5b3](https://github.com/pbi-agent/pbi-agent/commit/6c21e5b3)).
+
+## Internal
+
+- Rebuilt web static assets after frontend changes and stabilized generated asset hashes for repeatable builds ([72c8f35e](https://github.com/pbi-agent/pbi-agent/commit/72c8f35e), [ade907ff](https://github.com/pbi-agent/pbi-agent/commit/ade907ff), [0bb5c64c](https://github.com/pbi-agent/pbi-agent/commit/0bb5c64c)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.10.0"
+version = "0.11.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -971,7 +971,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Prepare pbi-agent v0.11.0 as a minor release from all commits after v0.10.0. This release focuses on workspace tooling, configurable tool visibility, project extensions/frontmatter, web Workspace Explorer improvements, and session/runtime stability.

## Highlights

### Added
- Project Python extensions for custom slash-command workflows.
- Configurable tool visibility across CLI, model profiles, web settings, commands, and sub-agents, including command-only `ask-user` support.
- Workspace switching, WSL folder picking, and a git-aware Workspace Explorer with icons, previews, diffs, changed-only filtering, and gitignore-aware scans.
- Session history search, project skill/agent enablement controls, `--include-history`, Claude Opus 4.8 model metadata, and sandbox executable temp mounts.

### Changed
- Consolidated workspace/file inspection around `explore_workspace` and active tool-spec driven prompts.
- Refactored the agent session runtime into focused modules and refined sub-agent working summaries.
- Refined session topbar/run-history/workspace explorer UI and settings catalog presentation.
- Enforced strict command/sub-agent model profiles and allowed tool groups.

### Fixed
- Fixed `explore_workspace` file-root/absolute-path handling while preserving confinement.
- Fixed include-history/tool-history replay, sub-agent activity state, topbar wrapping, and generated static asset churn.
- Fixed command profile/tool formatting issues, Kanban recovered-error advancement, and updated `idna` to 3.15.

### Removed
- Removed legacy tool and prompt assumptions replaced by `explore_workspace` and generated active tool prompts.
- Removed project settings notification cards in favor of preview-header metadata.

### Documentation
- Reorganized customization docs and expanded extension/tool/model-profile/CLI/session/sandbox/workspace-explorer coverage.

## Changelog

- `docs/changelog/v0.11.0.md`

## Validation

- [x] `uv run ruff check .` — passed
- [x] `uv run ruff format --check .` — passed
- [x] `uv run basedpyright` — passed
- [x] `uv run python scripts/dead_code.py` — passed
- [x] `uv run pytest -q --tb=short -x` — passed
- [x] `bun run docs:build` — passed

## Excluded / unrelated

- Local `TODO.md` session bookkeeping remains unstaged and is not part of this release PR.
