### PR TITLE
chore: release v0.12.1

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -146,6 +146,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.12.1', link: '/changelog/v0.12.1' },
           { text: 'v0.12.0', link: '/changelog/v0.12.0' },
           { text: 'v0.11.0', link: '/changelog/v0.11.0' },
           { text: 'v0.10.0', link: '/changelog/v0.10.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.12.1 - 2026-05-31](./v0.12.1.md)
 - [v0.12.0 - 2026-05-30](./v0.12.0.md)
 - [v0.11.0 - 2026-05-29](./v0.11.0.md)
 - [v0.10.0 - 2026-05-17](./v0.10.0.md)

--- a/docs/changelog/v0.12.1.md
+++ b/docs/changelog/v0.12.1.md
@@ -1,0 +1,12 @@
+---
+title: v0.12.1
+description: Changelog for pbi-agent v0.12.1, released on 2026-05-31.
+---
+
+# v0.12.1
+
+**Release date:** 2026-05-31
+
+## Internal
+
+- Updated post-release repository bookkeeping after v0.12.0; no user-facing product changes are included in this patch ([493c702d](https://github.com/pbi-agent/pbi-agent/commit/493c702d)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.12.0"
+version = "0.12.1"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -971,7 +971,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release v0.12.1 bumps package metadata and adds the patch changelog page for post-v0.12.0 internal bookkeeping. No user-facing product changes are included in this patch.

## Highlights

### Internal

- Updated post-release repository bookkeeping after v0.12.0 ([493c702d](https://github.com/pbi-agent/pbi-agent/commit/493c702d)).

## Changelog

- docs/changelog/v0.12.1.md

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run basedpyright`
- [x] `uv run python scripts/dead_code.py`
- [x] `uv run pytest -q --tb=short -x`
- [x] `bun run docs:build`

## Skipped / excluded

- Excluded session-only `TODO.md` changes from the release commit.
- Excluded local-only commits on the local `master` branch; this release branch is based on `origin/master`.
