### PR TITLE
chore: release v0.12.2

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -146,6 +146,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Changelog', link: '/changelog/' },
+          { text: 'v0.12.2', link: '/changelog/v0.12.2' },
           { text: 'v0.12.1', link: '/changelog/v0.12.1' },
           { text: 'v0.12.0', link: '/changelog/v0.12.0' },
           { text: 'v0.11.0', link: '/changelog/v0.11.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.12.2 - 2026-05-31](./v0.12.2.md)
 - [v0.12.1 - 2026-05-31](./v0.12.1.md)
 - [v0.12.0 - 2026-05-30](./v0.12.0.md)
 - [v0.11.0 - 2026-05-29](./v0.11.0.md)

--- a/docs/changelog/v0.12.2.md
+++ b/docs/changelog/v0.12.2.md
@@ -1,0 +1,28 @@
+---
+title: v0.12.2
+description: Changelog for pbi-agent v0.12.2, released on 2026-05-31.
+---
+
+# v0.12.2
+
+**Release date:** 2026-05-31
+
+## Added
+
+- Added a Split/Stacked diff layout toggle in Workspace Explorer, including synchronized split-pane scrolling for file diffs ([ee08ea18](https://github.com/pbi-agent/pbi-agent/commit/ee08ea18)).
+
+## Changed
+
+- Aligned Workspace Explorer preview actions so Diff/Raw and layout controls stay centered with consistent spacing ([1a0aa83e](https://github.com/pbi-agent/pbi-agent/commit/1a0aa83e)).
+
+## Fixed
+
+- Normalized Dashboard table header casing and filter dropdown typography for a cleaner, more consistent runs view ([4f29d5b7](https://github.com/pbi-agent/pbi-agent/commit/4f29d5b7)).
+
+## Removed
+
+- Removed the external Google Fonts dependency and switched UI typography to bundled/system fonts so the web app no longer calls Google Fonts at startup ([d28ffd5f](https://github.com/pbi-agent/pbi-agent/commit/d28ffd5f)).
+
+## Internal
+
+- Included the master bookkeeping commit that was missed by v0.12.1 ([34b24429](https://github.com/pbi-agent/pbi-agent/commit/34b24429)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.12.1"
+version = "0.12.2"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,11 @@ import pytest
 
 from pbi_agent.models.messages import TokenUsage, WebSearchSource
 from pbi_agent.web import uploads
+from pbi_agent.workspace_context import (
+    SANDBOX_ENV,
+    WORKSPACE_DISPLAY_PATH_ENV,
+    WORKSPACE_KEY_ENV,
+)
 
 
 class DisplaySpy:
@@ -199,6 +204,12 @@ def isolate_internal_config_path(monkeypatch: pytest.MonkeyPatch, tmp_path) -> N
 @pytest.fixture(autouse=True)
 def isolate_session_db(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     monkeypatch.setenv("PBI_AGENT_SESSION_DB_PATH", str(tmp_path / "sessions.db"))
+
+
+@pytest.fixture(autouse=True)
+def isolate_workspace_context_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (WORKSPACE_KEY_ENV, WORKSPACE_DISPLAY_PATH_ENV, SANDBOX_ENV):
+        monkeypatch.delenv(name, raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -971,7 +971,7 @@ excel = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release v0.12.2 packages the master commits that were not included in v0.12.1, including the Workspace Explorer diff layout updates, preview action alignment, bundled-font cleanup, and Dashboard styling fixes.

## Highlights

### Added
- Added a Split/Stacked diff layout toggle in Workspace Explorer with synchronized split-pane scrolling.

### Changed
- Aligned Workspace Explorer preview actions for more consistent Diff/Raw and layout controls.

### Fixed
- Normalized Dashboard table header casing and filter dropdown typography.
- Isolated pytest workspace-context environment variables so local sandbox env does not affect session/sub-agent tests.

### Removed
- Removed the external Google Fonts dependency; the web app now uses bundled/system fonts at startup.

### Internal
- Included the master bookkeeping commit that v0.12.1 missed.

## Changelog

- `docs/changelog/v0.12.2.md`

## Validation

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run basedpyright` — passed
- `uv run python scripts/dead_code.py` — passed
- `uv run pytest -q --tb=short -x` — passed
- `bun run docs:build` — passed

## Skipped / excluded / unrelated

- No PR numbers were available for the included master commits, so the changelog links directly to commits.
- Local session-only `MEMORY.md` and `TODO.md` changes are not included.