### PR TITLE
chore: release v0.26.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -147,6 +147,7 @@ export default defineConfig({
         collapsed: false,
         items: [
         { text: 'Changelog', link: '/changelog/' },
+        { text: 'v0.26.0', link: '/changelog/v0.26.0' },
         { text: 'v0.25.0', link: '/changelog/v0.25.0' },
         { text: 'v0.24.0', link: '/changelog/v0.24.0' },
         { text: 'v0.23.0', link: '/changelog/v0.23.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.26.0 - 2026-07-01](./v0.26.0.md)
 - [v0.25.0 - 2026-06-30](./v0.25.0.md)
 - [v0.24.0 - 2026-06-30](./v0.24.0.md)
 - [v0.23.0 - 2026-06-25](./v0.23.0.md)

--- a/docs/changelog/v0.26.0.md
+++ b/docs/changelog/v0.26.0.md
@@ -1,0 +1,16 @@
+---
+title: v0.26.0
+description: Changelog for pbi-agent v0.26.0, released on 2026-07-01.
+---
+
+# v0.26.0
+
+**Release date:** 2026-07-01
+
+## Changed
+
+- Added Claude Sonnet 5, Claude Fable 5, and Claude Mythos 5 to the bundled model catalog so cost estimates and context windows are available immediately ([9fc9b254](https://github.com/pbi-agent/pbi-agent/commit/9fc9b254537eea61f252fce7a55f407c9c775352)).
+
+## Fixed
+
+- Updated live run detail headers to show cached and reasoning token metrics during ongoing runs, including ChatGPT WebSocket sessions and upgraded existing session databases ([47d9446f](https://github.com/pbi-agent/pbi-agent/commit/47d9446f73d35e9cba79848e2abf8965a9c7ea8c)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.25.0"
+version = "0.26.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -473,7 +473,7 @@ wheels = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.25.0"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "codetool-explore" },


### PR DESCRIPTION
## Summary

Prepare pbi-agent v0.26.0 with live run detail token metric fixes and updated Claude model catalog entries.

## Highlights

### Changed
- Added Claude Sonnet 5, Claude Fable 5, and Claude Mythos 5 to the bundled model catalog.

### Fixed
- Updated live run detail headers to show cached and reasoning token metrics while runs are still ongoing, including ChatGPT WebSocket sessions and upgraded existing session databases.

## Changelog

- docs/changelog/v0.26.0.md

## Validation

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run basedpyright` — passed
- `uv run python scripts/dead_code.py` — passed
- `uv run pytest -q --tb=short -x` — passed on rerun; initial full-suite run hit a transient `test_checkpoint_follow_up_is_pending_and_drained_before_turn_end` failure, focused rerun passed, then full rerun passed
- `bun run docs:build` — passed
- `git diff --cached --check` — passed before commit

## Skipped / excluded

- No unrelated workspace changes included.
- Post-v0.25.0 bookkeeping and merge commits remain in history but have no user-facing changelog entry.
