### PR TITLE
chore: release v0.29.0

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,7 +1,7 @@
 # MEMORY.md
 
 ## Metadata
-- Last compacted: 2026-07-11
+- Last compacted: 2026-07-12
 - Scope: durable repo memory + active-day task events.
 - Format: only `Metadata`, `Long-Term Memory`, and `Detailed Task Events`.
 
@@ -29,7 +29,7 @@
 - Model catalog: bundled pricing includes GPT-5.6 Sol/Terra/Luna plus the `gpt-5.6`→Sol alias, `glm-5.2`, `minimax-m3`, `claude-sonnet-5`, `claude-fable-5`, and `claude-mythos-5`; catalog key lookups use longest case-insensitive exact/prefix matching. OpenAI Responses maps `input_tokens_details.cache_write_tokens` into `TokenUsage`, priced as the catalog cache-write bucket.
 - Reasoning efforts: provider model discovery exposes advertised effort strings; profile suggestions use the selected main/sub-agent models' compatible values and fall back to `low`/`medium`/`high`/`xhigh`. Arbitrary non-empty custom values are accepted and forwarded unchanged (while existing generic mappings such as Anthropic `xhigh`→`max` remain). Classic OpenAI `/v1/models` has no capability metadata, so generic provider/model-pattern rules hard-code documented GPT-5/o-series/Codex effort sets and enrich discovery.
 - OpenAI/ChatGPT: Responses use `instructions` + `previous_response_id`; Responses requests include `reasoning.encrypted_content` alongside provider-specific include values. OpenAI profiles alone persist optional `reasoning.mode` (`standard`/`pro`), validated against selected main/sub-agent GPT-5.6 models and forwarded only to the classic OpenAI API; official Codex does not send it to the ChatGPT subscription backend. GitHub Copilot Responses does not support `previous_response_id`; replay local history for user turns and tool follow-ups. ChatGPT subscription prepends system prompt. ChatGPT Codex client/model-discovery minimum is 0.144.1. Codex transport is WebSocket-only with split timeouts/retry events, closes parent sockets before sub-agent runs, caps write/first-event/close waits at 30s/30s/1s, and has no unsupported compression.
-- Saved-session replay: cross-provider replay falls back to canonical message/tool history when raw traces incompatible. Responses replay strips output-only fields before request history. Responses-style providers persist/replay only final assistant output message while live display may show intermediate messages.
+- Saved-session replay: cross-provider replay falls back to canonical message/tool history when raw traces incompatible. Responses replay strips output-only fields before request history. Responses-style providers persist/replay only final assistant output message while live display may show intermediate messages. Continuations after stale or server-shutdown-interrupted web runs restore the interrupted user/intermediate/tool trace, match retained messages to runs, and include only complete tool call/result pairs.
 - Google Interactions: saved-session/stateless replay uses steps input (`user_input`, `model_output`, tool/result steps), not role/content turn-list objects; fresh single turns may use simple string/content input.
 - `google_gcp`: provider wrapper with Vertex/Gemini shape handlers for Gemini `generateContent`, OpenAI Chat Completions, OpenAI Responses/xAI, Anthropic Messages. Uses client-side history for GCP xAI/Responses. Does not advertise native web search until shape-native tools exist. Same-shape runtime changes update active shape/protocol in place so history survives model/max-token/tool changes.
 - `google_gcp` auth/endpoints: derive Vertex project/location from saved provider or CLI before env fallback. API-key-like tokens/envs use `x-goog-api-key` + Gemini express `v1beta1`; express unsupported-token errors retry once with standard Vertex OAuth/ADC using saved project/location. Non-Gemini Vertex shapes skip API-key-like auth and use OAuth2/ADC; forced API-key auth errors early. ADC via `gcloud auth application-default print-access-token`, timeout default 30s overrideable by `PBI_AGENT_GOOGLE_GCP_ACCESS_TOKEN_TIMEOUT`; bearer cached until expiry and refreshed once after expiry errors. Strip `google/` model prefix for Gemini endpoint paths. GCP Responses tool schemas drop unsupported JSON-Schema combinators like `oneOf`.
@@ -56,7 +56,5 @@
 
 ## Detailed Task Events
 
-## 2026-07-11
-- Prompt-enhancement profile: added persisted optional model-profile selection/API/Settings; selected profiles override blank and saved-session enhancement runtimes while preserving context, and `Current model` restores existing fallback. Validation: full Python/frontend checks, API codegen/build, and correctness/quality reviews passed.
-- Sub-agent timeout: raised elapsed runtime cap from 1200s to 1800s and aligned docs (including the existing 400-request cap). Validation: focused Ruff/format, 41 sub-agent tests, docs build, and diff checks passed.
-- Release v0.28.0: included all five local commits since v0.27.0, merged PR #339, and published the tag, corrected GitHub notes, wheel, and sdist. Validation: required local release checks, PR checks, and Release workflow passed.
+## 2026-07-12
+- Crash-resume diagnosis/fix: session `67f4fbc3cdb04ee0b18dd5d4c277d58a` proved reconstruction retained both valid tool exchanges, but clean shutdown status `interrupted` did not activate it; crash detection now accepts `interrupted` and `stale`. Validation: full session/web test files, Ruff/format, basedpyright, and diff check passed.

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,5 @@
-- [x] Fetch release refs and reconcile local/remote unreleased commits
-- [x] Determine v0.28.0 release scope and collect PR metadata
-- [x] Create release branch and update version/changelog/sidebar
-- [x] Run required release validation
-- [x] Commit and push release-scoped changes
-- [x] Open and merge the release PR
-- [x] Verify release tag, GitHub Release notes, and package publish
-- [x] Update release task memory
+- [x] Inspect the failing session's persisted messages, runs, and events
+- [x] Identify and reproduce the crash-resume history mismatch
+- [x] Fix history reconstruction and add regression coverage
+- [x] Run focused and required backend validation
+- [x] Update task memory

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -147,6 +147,7 @@ export default defineConfig({
         collapsed: false,
         items: [
         { text: 'Changelog', link: '/changelog/' },
+        { text: 'v0.29.0', link: '/changelog/v0.29.0' },
         { text: 'v0.28.0', link: '/changelog/v0.28.0' },
         { text: 'v0.27.0', link: '/changelog/v0.27.0' },
         { text: 'v0.26.0', link: '/changelog/v0.26.0' },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -11,6 +11,7 @@ Each release has its own changelog page named with the release version. Release 
 
 ## Releases
 
+- [v0.29.0 - 2026-07-12](./v0.29.0.md)
 - [v0.28.0 - 2026-07-11](./v0.28.0.md)
 - [v0.27.0 - 2026-07-10](./v0.27.0.md)
 - [v0.26.0 - 2026-07-01](./v0.26.0.md)

--- a/docs/changelog/v0.29.0.md
+++ b/docs/changelog/v0.29.0.md
@@ -1,0 +1,12 @@
+---
+title: v0.29.0
+description: Changelog for pbi-agent v0.29.0, released on 2026-07-12.
+---
+
+# v0.29.0
+
+**Release date:** 2026-07-12
+
+## Fixed
+
+- Restored interrupted saved-session progress across server restarts, including intermediate responses and only complete tool call/result exchanges ([2c676c54](https://github.com/pbi-agent/pbi-agent/commit/2c676c54454942e943613296a3a9ec41f31ab367)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pbi-agent"
-version = "0.28.0"
+version = "0.29.0"
 description = "Multi-provider lightweight local coding agent"
 readme = "README.md"
 license = "MIT"

--- a/src/pbi_agent/agent/session/history.py
+++ b/src/pbi_agent/agent/session/history.py
@@ -119,7 +119,10 @@ def _refresh_provider_history_from_store(
         messages = []
         history_items = []
         if store is not None and session_id is not None:
-            messages = _messages_for_provider_restore(store.list_messages(session_id))
+            messages = _messages_for_provider_restore(
+                store.list_messages(session_id),
+                preserve_trailing_user=include_tool_history,
+            )
             if include_tool_history:
                 history_items = _history_items_for_provider_restore(
                     store,
@@ -278,7 +281,10 @@ def _resume_session(
     except Exception:
         _log.warning("Failed to restore session state", exc_info=True)
     if messages:
-        provider_messages = _messages_for_provider_restore(messages)
+        provider_messages = _messages_for_provider_restore(
+            messages,
+            preserve_trailing_user=include_tool_history,
+        )
         try:
             if include_tool_history:
                 restore_history_items = getattr(provider, "restore_history_items", None)
@@ -303,6 +309,8 @@ def _resume_session(
 
 def _messages_for_provider_restore(
     messages: list[MessageRecord],
+    *,
+    preserve_trailing_user: bool = False,
 ) -> list[MessageRecord]:
     from pbi_agent.agent.session.compaction import (
         active_context_messages,
@@ -322,7 +330,7 @@ def _messages_for_provider_restore(
             *restored[:latest_summary_index],
             *restored[latest_summary_index + 1 :],
         ]
-    while restored and restored[-1].role == "user":
+    while restored and restored[-1].role == "user" and not preserve_trailing_user:
         restored.pop()
     return restored
 
@@ -353,17 +361,62 @@ def _message_tool_history_items_for_provider_restore(
 ) -> list[dict[str, Any]]:
     history_items: list[dict[str, Any]] = []
     run_tool_histories = _tool_history_by_run(store, session_id)
-    run_index = 0
+    histories_by_message_id = _run_histories_for_messages(
+        run_tool_histories,
+        messages,
+    )
     pending_user = False
+    pending_message: MessageRecord | None = None
     for message in messages:
+        if message.role == "user" and pending_user:
+            run_history = (
+                histories_by_message_id.get(pending_message.id)
+                if pending_message is not None
+                else None
+            )
+            if run_history is not None:
+                run, items, _intermediate_text, _user_text = run_history
+                history_items.extend(
+                    _interrupted_generic_run_items(
+                        run,
+                        pending_message,
+                        items,
+                    )
+                )
+            else:
+                history_items.pop()
         history_items.append({"type": "message", "message": message})
         if message.role == "user":
             pending_user = True
+            pending_message = message
         elif message.role == "assistant" and pending_user:
-            if run_index < len(run_tool_histories):
-                history_items[-1:-1] = run_tool_histories[run_index]
-                run_index += 1
+            run_history = (
+                histories_by_message_id.get(pending_message.id)
+                if pending_message is not None
+                else None
+            )
+            if run_history is not None:
+                run, items, _intermediate_text, _user_text = run_history
+                history_items[-1:-1] = _completed_generic_run_items(items)
             pending_user = False
+            pending_message = None
+    if pending_user:
+        run_history = (
+            histories_by_message_id.get(pending_message.id)
+            if pending_message is not None
+            else None
+        )
+        if run_history is not None:
+            run, items, _intermediate_text, _user_text = run_history
+            history_items.extend(
+                _interrupted_generic_run_items(
+                    run,
+                    pending_message,
+                    items,
+                )
+            )
+        else:
+            history_items.pop()
     return history_items
 
 
@@ -413,7 +466,7 @@ def _response_history_items_for_provider_restore(
         return []
 
     history_items: list[dict[str, Any]] = []
-    run_index = 0
+    histories_by_message_id = _run_histories_for_messages(run_histories, messages)
     used_response_history = False
     pending_user: MessageRecord | None = None
     current_provider = _provider_history_name(provider)
@@ -421,20 +474,42 @@ def _response_history_items_for_provider_restore(
     for message in messages:
         if message.role == "user":
             if pending_user is not None:
-                return []
+                run_history = histories_by_message_id.get(pending_user.id)
+                if run_history is None:
+                    return []
+                run, events, completed_tool_results, _user_text = run_history
+                if (
+                    current_provider is not None
+                    and _run_provider_name(run) != current_provider
+                ):
+                    return []
+                turn_items = _response_history_items_for_run(
+                    events,
+                    pending_user,
+                    completed_tool_results=completed_tool_results,
+                    require_completed_tool_exchange=True,
+                )
+                if not turn_items:
+                    return []
+                history_items.extend(turn_items)
+                used_response_history = True
             pending_user = message
             continue
         if message.role == "assistant" and pending_user is not None:
-            if run_index >= len(run_histories):
+            run_history = histories_by_message_id.get(pending_user.id)
+            if run_history is None:
                 return []
-            run, events = run_histories[run_index]
-            run_index += 1
+            run, events, completed_tool_results, _user_text = run_history
             if (
                 current_provider is not None
                 and _run_provider_name(run) != current_provider
             ):
                 return []
-            turn_items = _response_history_items_for_run(events, pending_user)
+            turn_items = _response_history_items_for_run(
+                events,
+                pending_user,
+                completed_tool_results=completed_tool_results,
+            )
             if turn_items:
                 history_items.extend(turn_items)
                 used_response_history = True
@@ -447,7 +522,22 @@ def _response_history_items_for_provider_restore(
         history_items.append({"type": "message", "message": message})
 
     if pending_user is not None:
-        return []
+        run_history = histories_by_message_id.get(pending_user.id)
+        if run_history is None:
+            return []
+        run, events, completed_tool_results, _user_text = run_history
+        if current_provider is not None and _run_provider_name(run) != current_provider:
+            return []
+        turn_items = _response_history_items_for_run(
+            events,
+            pending_user,
+            completed_tool_results=completed_tool_results,
+            require_completed_tool_exchange=True,
+        )
+        if not turn_items:
+            return []
+        history_items.extend(turn_items)
+        used_response_history = True
 
     return history_items if used_response_history else []
 
@@ -455,22 +545,32 @@ def _response_history_items_for_provider_restore(
 def _response_model_call_history_by_run(
     store: SessionStore,
     session_id: str,
-) -> list[tuple[Any, list[Any]]]:
-    histories: list[tuple[Any, list[Any]]] = []
+) -> list[tuple[Any, list[Any], dict[str, Any], str]]:
+    histories: list[tuple[Any, list[Any], dict[str, Any], str]] = []
     for run in store.list_run_sessions(session_id):
         if run.parent_run_session_id or run.agent_name not in {None, "main"}:
             continue
         if run.agent_type not in {"session_turn", "single_turn"}:
             continue
+        run_events = store.list_observability_events(run_session_id=run.run_session_id)
         events = [
             event
-            for event in store.list_observability_events(
-                run_session_id=run.run_session_id
-            )
+            for event in run_events
             if event.event_type == "model_call" and event.success != 0
         ]
-        if events:
-            histories.append((run, events))
+        completed_tool_results = {
+            event.tool_call_id: event
+            for event in run_events
+            if event.event_type == "tool_call" and event.tool_call_id
+        }
+        histories.append(
+            (
+                run,
+                events,
+                completed_tool_results,
+                _run_user_input_text(events),
+            )
+        )
     return histories
 
 
@@ -479,15 +579,88 @@ def _run_provider_name(run: Any) -> str | None:
     return provider_name or None
 
 
+def _run_histories_for_messages(
+    histories: list[tuple[Any, ...]],
+    messages: list[MessageRecord],
+) -> dict[int, tuple[Any, ...]]:
+    ordered = sorted(histories, key=lambda item: (item[0].started_at, item[0].id))
+    upper_bound = len(ordered)
+    matched: dict[int, tuple[Any, ...]] = {}
+    user_messages = [message for message in messages if message.role == "user"]
+    for message in reversed(user_messages):
+        candidates = list(enumerate(ordered[:upper_bound]))
+        exact = [
+            (index, history)
+            for index, history in candidates
+            if isinstance(history[-1], str)
+            and history[-1].strip() == message.content.strip()
+        ]
+        provider_exact = [
+            (index, history)
+            for index, history in exact
+            if message.provider_id
+            and message.provider_id in {history[0].provider_id, history[0].provider}
+        ]
+        available = provider_exact or exact or candidates
+        if not available:
+            continue
+        index, history = available[-1]
+        matched[message.id] = history
+        upper_bound = index
+    return matched
+
+
+def _run_user_input_text(events: list[Any]) -> str:
+    for event in events:
+        payload = _json_field(event.request_payload_json)
+        if not isinstance(payload, dict):
+            continue
+        request_items = _request_input_items(payload)
+        for item in reversed(request_items):
+            if str(item.get("role") or "").lower() == "user":
+                return _input_item_text(item.get("content"))
+        messages = payload.get("messages")
+        if isinstance(messages, list):
+            for message in reversed(messages):
+                if (
+                    isinstance(message, dict)
+                    and str(message.get("role") or "").lower() == "user"
+                ):
+                    return _input_item_text(message.get("content"))
+        contents = payload.get("contents")
+        if isinstance(contents, list):
+            for content in reversed(contents):
+                if (
+                    isinstance(content, dict)
+                    and str(content.get("role") or "").lower() == "user"
+                ):
+                    return _parts_text(content.get("parts"))
+        steps = payload.get("steps")
+        if isinstance(steps, list):
+            for step in reversed(steps):
+                if isinstance(step, dict) and step.get("type") == "user_input":
+                    return _input_item_text(step.get("content"))
+    return ""
+
+
 def _response_history_items_for_run(
     events: list[Any],
     user_message: MessageRecord,
+    *,
+    completed_tool_results: dict[str, Any] | None = None,
+    require_completed_tool_exchange: bool = False,
 ) -> list[dict[str, Any]]:
     history_items: list[dict[str, Any]] = []
     turn_items: list[dict[str, Any]] = []
     item_batches: list[tuple[list[dict[str, Any]], list[dict[str, Any]]]] = []
     first_model_call = True
     saw_assistant_message_output = False
+    request_output_ids = {
+        call_id
+        for event in events
+        for item in _request_input_items(_json_field(event.request_payload_json))
+        if (call_id := _response_tool_output_call_id(item)) is not None
+    }
 
     for event in events:
         request_items = _request_input_items(_json_field(event.request_payload_json))
@@ -504,6 +677,14 @@ def _response_history_items_for_run(
 
         response_items = _provider_response_output_items(
             _json_field(event.response_payload_json)
+        )
+        response_items.extend(
+            _missing_response_tool_outputs(
+                response_items,
+                turn_items,
+                completed_tool_results or {},
+                request_output_ids,
+            )
         )
         saw_assistant_message_output = saw_assistant_message_output or any(
             _is_assistant_message_output_item(item) for item in response_items
@@ -529,7 +710,53 @@ def _response_history_items_for_run(
                 )
             )
         )
-    return history_items if saw_assistant_message_output else []
+    if require_completed_tool_exchange and not completed_call_ids:
+        return []
+    if not saw_assistant_message_output and not require_completed_tool_exchange:
+        return []
+    return history_items
+
+
+def _missing_response_tool_outputs(
+    response_items: list[dict[str, Any]],
+    previous_items: list[dict[str, Any]],
+    completed_tool_results: dict[str, Any],
+    request_output_ids: set[str],
+) -> list[dict[str, Any]]:
+    existing_output_ids = {
+        call_id
+        for item in [*previous_items, *response_items]
+        if (call_id := _response_tool_output_call_id(item)) is not None
+    }
+    outputs: list[dict[str, Any]] = []
+    for item in response_items:
+        call_id = _response_tool_input_call_id(item)
+        if (
+            call_id is None
+            or call_id in existing_output_ids
+            or call_id in request_output_ids
+            or call_id not in completed_tool_results
+        ):
+            continue
+        event = completed_tool_results[call_id]
+        output = _json_field(event.tool_output_json)
+        outputs.append(
+            {
+                "type": (
+                    "custom_tool_call_output"
+                    if item.get("type") == "custom_tool_call"
+                    else "function_call_output"
+                ),
+                "call_id": call_id,
+                "output": (
+                    output
+                    if isinstance(output, str)
+                    else json.dumps(output, separators=(",", ":"))
+                ),
+            }
+        )
+        existing_output_ids.add(call_id)
+    return outputs
 
 
 def _request_input_items(payload: Any) -> list[dict[str, Any]]:
@@ -610,6 +837,16 @@ def _input_item_text(content: Any) -> str:
     return "".join(text_parts)
 
 
+def _parts_text(parts: Any) -> str:
+    if not isinstance(parts, list):
+        return ""
+    return "".join(
+        str(part.get("text") or "")
+        for part in parts
+        if isinstance(part, dict) and not bool(part.get("thought"))
+    )
+
+
 def _new_input_delta(
     request_items: list[dict[str, Any]],
     existing_items: list[dict[str, Any]],
@@ -668,7 +905,7 @@ def _completed_response_tool_call_ids(
     call_ids: set[str] = set()
     output_ids: set[str] = set()
     for delta_items, response_items in item_batches:
-        for item in delta_items:
+        for item in [*delta_items, *response_items]:
             if call_id := _response_tool_output_call_id(item):
                 output_ids.add(call_id)
         for item in response_items:
@@ -743,24 +980,33 @@ def _clone_json_value(value: Any) -> Any:
 def _tool_history_by_run(
     store: SessionStore,
     session_id: str,
-) -> list[list[dict[str, Any]]]:
-    histories: list[list[dict[str, Any]]] = []
+) -> list[tuple[Any, list[dict[str, Any]], str, str]]:
+    histories: list[tuple[Any, list[dict[str, Any]], str, str]] = []
     for run in store.list_run_sessions(session_id):
         if run.parent_run_session_id or run.agent_name not in {None, "main"}:
             continue
+        if run.agent_type not in {"session_turn", "single_turn"}:
+            continue
         run_items: list[dict[str, Any]] = []
         seen_calls: dict[str, dict[str, Any]] = {}
-        for event in store.list_observability_events(run_session_id=run.run_session_id):
+        intermediate_parts: list[str] = []
+        run_events = store.list_observability_events(run_session_id=run.run_session_id)
+        for event in run_events:
             if event.event_type == "model_call":
-                calls = _tool_calls_from_response_payload(
+                response_items = _generic_response_history_items(
                     _json_field(event.response_payload_json)
                 )
-                for call in calls:
-                    seen_calls[call["call_id"]] = call
-                if len(calls) == 1:
-                    run_items.append(calls[0])
-                elif calls:
-                    run_items.append({"type": "tool_call_group", "calls": calls})
+                response_items = _group_response_tool_calls(response_items)
+                for item in response_items:
+                    if item.get("type") == "intermediate_text":
+                        intermediate_parts.append(str(item.get("content") or ""))
+                    elif item.get("type") == "tool_call":
+                        seen_calls[item["call_id"]] = item
+                    elif item.get("type") == "tool_call_group":
+                        for call in item.get("calls", []):
+                            if isinstance(call, dict) and call.get("call_id"):
+                                seen_calls[call["call_id"]] = call
+                    run_items.append(item)
             elif event.event_type == "tool_call" and event.tool_call_id:
                 if event.tool_call_id not in seen_calls:
                     call = {
@@ -787,9 +1033,51 @@ def _tool_history_by_run(
                     }
                 )
         run_items = _filter_incomplete_tool_exchange_items(run_items)
-        if run_items:
-            histories.append(_group_parallel_tool_results(run_items))
+        histories.append(
+            (
+                run,
+                _group_parallel_tool_results(run_items),
+                "\n\n".join(intermediate_parts),
+                _run_user_input_text(run_events),
+            )
+        )
     return histories
+
+
+def _interrupted_generic_run_items(
+    run: Any,
+    user_message: MessageRecord | None,
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    restored: list[dict[str, Any]] = []
+    for index, item in enumerate(items):
+        if item.get("type") != "intermediate_text":
+            restored.append(item)
+            continue
+        content = str(item.get("content") or "")
+        if not content or user_message is None:
+            continue
+        restored.append(
+            {
+                "type": "message",
+                "message": MessageRecord(
+                    id=-(int(run.id) * 1000 + index + 1),
+                    session_id=user_message.session_id,
+                    role="assistant",
+                    content=content,
+                    created_at=run.started_at,
+                    provider_id=run.provider_id,
+                    profile_id=run.profile_id,
+                ),
+            }
+        )
+    return restored
+
+
+def _completed_generic_run_items(
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [item for item in items if item.get("type") != "intermediate_text"]
 
 
 def _filter_incomplete_tool_exchange_items(
@@ -909,6 +1197,113 @@ def _tool_calls_from_response_payload(payload: Any) -> list[dict[str, Any]]:
     return calls
 
 
+def _generic_response_history_items(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    items: list[dict[str, Any]] = []
+    choices = payload.get("choices")
+    if isinstance(choices, list):
+        for choice in choices:
+            message = choice.get("message") if isinstance(choice, dict) else None
+            if not isinstance(message, dict):
+                continue
+            if text := _input_item_text(message.get("content")):
+                items.append({"type": "intermediate_text", "content": text})
+            items.extend(
+                _tool_calls_from_response_payload({"choices": [{"message": message}]})
+            )
+        return _deduplicate_adjacent_history_items(items)
+    raw_items = _response_output_items(payload)
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") in {"message", "model_output"}:
+            if text := _input_item_text(item.get("content")):
+                items.append({"type": "intermediate_text", "content": text})
+        items.extend(_tool_calls_from_response_payload({"output": [item]}))
+    content = payload.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text":
+                text = block.get("text")
+                if isinstance(text, str) and text:
+                    items.append({"type": "intermediate_text", "content": text})
+            elif block.get("type") == "tool_use":
+                call_id = block.get("id")
+                if isinstance(call_id, str) and call_id:
+                    items.append(
+                        {
+                            "type": "tool_call",
+                            "call_id": call_id,
+                            "name": str(block.get("name") or ""),
+                            "arguments": block.get("input"),
+                            "kind": "function",
+                        }
+                    )
+    candidates = payload.get("candidates")
+    if isinstance(candidates, list):
+        for candidate in candidates:
+            content = candidate.get("content") if isinstance(candidate, dict) else None
+            parts = content.get("parts") if isinstance(content, dict) else None
+            if not isinstance(parts, list):
+                continue
+            for part in parts:
+                if not isinstance(part, dict) or bool(part.get("thought")):
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text:
+                    items.append({"type": "intermediate_text", "content": text})
+                function_call = part.get("functionCall")
+                if not isinstance(function_call, dict):
+                    function_call = part.get("function_call")
+                if isinstance(function_call, dict):
+                    call_id = function_call.get("id") or function_call.get("call_id")
+                    if isinstance(call_id, str) and call_id:
+                        items.append(
+                            {
+                                "type": "tool_call",
+                                "call_id": call_id,
+                                "name": str(function_call.get("name") or ""),
+                                "arguments": function_call.get("args") or {},
+                                "kind": "function",
+                            }
+                        )
+    return _deduplicate_adjacent_history_items(items)
+
+
+def _deduplicate_adjacent_history_items(
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    deduplicated: list[dict[str, Any]] = []
+    for item in items:
+        if deduplicated and item == deduplicated[-1]:
+            continue
+        deduplicated.append(item)
+    return deduplicated
+
+
+def _group_response_tool_calls(
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    grouped: list[dict[str, Any]] = []
+    index = 0
+    while index < len(items):
+        if items[index].get("type") != "tool_call":
+            grouped.append(items[index])
+            index += 1
+            continue
+        calls: list[dict[str, Any]] = []
+        while index < len(items) and items[index].get("type") == "tool_call":
+            calls.append(items[index])
+            index += 1
+        grouped.append(
+            calls[0] if len(calls) == 1 else {"type": "tool_call_group", "calls": calls}
+        )
+    return grouped
+
+
 def _response_output_items(payload: dict[str, Any]) -> list[Any]:
     output = payload.get("output")
     if isinstance(output, list):
@@ -916,6 +1311,9 @@ def _response_output_items(payload: dict[str, Any]) -> list[Any]:
     outputs = payload.get("outputs")
     if isinstance(outputs, list):
         return outputs
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        return [step for step in steps if isinstance(step, dict)]
     choices = payload.get("choices")
     if not isinstance(choices, list):
         return []

--- a/src/pbi_agent/web/session/live_sessions.py
+++ b/src/pbi_agent/web/session/live_sessions.py
@@ -372,6 +372,9 @@ class LiveSessionsMixin(FollowUpsMixin, ImageUploadsMixin):
         follow_up_delivery: FollowUpDelivery | None = None,
     ) -> dict[str, Any]:
         self._ensure_saved_session_title(session_id, text)
+        include_tool_history = include_tool_history or (
+            self._saved_session_needs_crash_resume(session_id)
+        )
         live_session = self._find_live_session_for_saved_session(session_id)
         reuse_existing = True
         if live_session is not None and live_session.kind == "task":
@@ -406,6 +409,17 @@ class LiveSessionsMixin(FollowUpsMixin, ImageUploadsMixin):
             include_tool_history=include_tool_history,
             follow_up_delivery=follow_up_delivery,
         )
+
+    def _saved_session_needs_crash_resume(self, session_id: str) -> bool:
+        with SessionStore() as store:
+            record = store.get_session(session_id)
+            if record is None or record.directory != self._directory_key:
+                raise KeyError(session_id)
+            latest_web_run = store.get_latest_web_session_run(session_id)
+        return latest_web_run is not None and latest_web_run.status in {
+            "interrupted",
+            "stale",
+        }
 
     def _command_profile_id_for_submission(
         self,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -689,6 +689,309 @@ def test_run_single_turn_restores_tool_history_when_enabled(
     ]
 
 
+def test_run_single_turn_restores_completed_tools_from_interrupted_turn(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    provider = _ProviderStub()
+    display = _SessionDisplaySpy([])
+    settings = Settings(api_key="test-key", provider="openai")
+
+    with SessionStore() as store:
+        session_id = store.create_session(str(tmp_path), "openai", DEFAULT_MODEL)
+        store.add_message(session_id, "user", "interrupted request")
+        run_id = store.create_run_session(
+            run_session_id="run-interrupted",
+            session_id=session_id,
+            agent_name="main",
+            agent_type="session_turn",
+            provider="openai",
+            provider_id=None,
+            profile_id=None,
+            model=DEFAULT_MODEL,
+            status="stale",
+        )
+        store.add_observability_event(
+            run_session_id=run_id,
+            session_id=session_id,
+            step_index=0,
+            event_type="model_call",
+            request_payload={
+                "input": [{"role": "user", "content": "interrupted request"}],
+            },
+            response_payload={
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "phase": "commentary",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "I found the relevant module.",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call_complete",
+                        "name": "shell",
+                        "arguments": '{"command": "pwd"}',
+                    },
+                ]
+            },
+            success=True,
+        )
+        store.add_observability_event(
+            run_session_id=run_id,
+            session_id=session_id,
+            step_index=1,
+            event_type="tool_call",
+            tool_name="shell",
+            tool_call_id="call_complete",
+            tool_input={"command": "pwd"},
+            tool_output={"ok": True, "result": "/workspace"},
+            success=True,
+        )
+        store.add_observability_event(
+            run_session_id=run_id,
+            session_id=session_id,
+            step_index=2,
+            event_type="model_call",
+            request_payload={
+                "input": [
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_complete",
+                        "output": '{"ok": true, "result": "/workspace"}',
+                    }
+                ]
+            },
+            response_payload={
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "phase": "commentary",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Now I will inspect the file.",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call_incomplete",
+                        "name": "shell",
+                        "arguments": '{"command": "cat app.py"}',
+                    },
+                ]
+            },
+            success=True,
+        )
+
+    monkeypatch.setattr(
+        "pbi_agent.agent.session._open_runtime_provider",
+        _stub_runtime_provider(provider),
+    )
+
+    run_single_turn(
+        "Continue from the crash",
+        settings,
+        display,
+        resume_session_id=session_id,
+        include_tool_history=True,
+    )
+
+    assert provider.restored_history_items is not None
+    restored_items = [item["item"] for item in provider.restored_history_items]
+    assert [item.get("type", item.get("role")) for item in restored_items] == [
+        "user",
+        "message",
+        "function_call",
+        "function_call_output",
+        "message",
+    ]
+    assert restored_items[0]["content"] == "interrupted request"
+    assert restored_items[3]["call_id"] == "call_complete"
+    assert all(item.get("call_id") != "call_incomplete" for item in restored_items)
+
+
+def test_interrupted_response_history_uses_persisted_tool_result_without_next_model_call(
+    tmp_path,
+) -> None:
+    provider = _ProviderStub()
+    with SessionStore(db_path=tmp_path / "sessions.db") as store:
+        session_id = store.create_session(str(tmp_path), "openai", DEFAULT_MODEL)
+        store.add_message(session_id, "user", "interrupted request")
+        messages = store.list_messages(session_id)
+        run_id = store.create_run_session(
+            run_session_id="run-crashed-after-tool",
+            session_id=session_id,
+            agent_name="main",
+            agent_type="session_turn",
+            provider="openai",
+            provider_id=None,
+            profile_id=None,
+            model=DEFAULT_MODEL,
+            status="stale",
+        )
+        store.add_observability_event(
+            run_session_id=run_id,
+            session_id=session_id,
+            step_index=0,
+            event_type="model_call",
+            request_payload={
+                "input": [{"role": "user", "content": "interrupted request"}],
+            },
+            response_payload={
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "phase": "commentary",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "I found the target and will inspect it.",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call_complete",
+                        "name": "shell",
+                        "arguments": '{"command": "pwd"}',
+                    },
+                ]
+            },
+            success=True,
+        )
+        store.add_observability_event(
+            run_session_id=run_id,
+            session_id=session_id,
+            step_index=1,
+            event_type="tool_call",
+            tool_name="shell",
+            tool_call_id="call_complete",
+            tool_input={"command": "pwd"},
+            tool_output={"ok": True, "result": "/workspace"},
+            success=True,
+        )
+
+        history = session_module.history_items_for_provider_restore(
+            store,
+            session_id,
+            messages,
+            provider=provider,
+        )
+
+    restored_items = [item["item"] for item in history]
+    assert [item.get("type", item.get("role")) for item in restored_items] == [
+        "user",
+        "message",
+        "function_call",
+        "function_call_output",
+    ]
+    assert json.loads(restored_items[-1]["output"]) == {
+        "ok": True,
+        "result": "/workspace",
+    }
+
+
+def test_generic_interrupted_tool_history_stays_aligned_after_no_tool_turn(
+    tmp_path,
+) -> None:
+    provider = _ProviderStub(provider_name="anthropic")
+    with SessionStore(db_path=tmp_path / "sessions.db") as store:
+        session_id = store.create_session(str(tmp_path), "anthropic", DEFAULT_MODEL)
+        store.add_message(session_id, "user", "first request")
+        store.add_message(session_id, "assistant", "first answer")
+        store.add_message(session_id, "user", "interrupted request")
+        messages = store.list_messages(session_id)
+        store.create_run_session(
+            run_session_id="run-without-tools",
+            session_id=session_id,
+            agent_name="main",
+            agent_type="session_turn",
+            provider="anthropic",
+            provider_id=None,
+            profile_id=None,
+            model=DEFAULT_MODEL,
+            status="completed",
+        )
+        interrupted_run_id = store.create_run_session(
+            run_session_id="run-with-tools",
+            session_id=session_id,
+            agent_name="main",
+            agent_type="session_turn",
+            provider="anthropic",
+            provider_id=None,
+            profile_id=None,
+            model=DEFAULT_MODEL,
+            status="stale",
+        )
+        store.add_observability_event(
+            run_session_id=interrupted_run_id,
+            session_id=session_id,
+            step_index=0,
+            event_type="model_call",
+            request_payload={
+                "messages": [
+                    {"role": "user", "content": "interrupted request"},
+                ]
+            },
+            response_payload={
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "I found the module and will inspect it.",
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "call_interrupted",
+                        "name": "shell",
+                        "input": {"command": "pwd"},
+                    },
+                ]
+            },
+            success=True,
+        )
+        store.add_observability_event(
+            run_session_id=interrupted_run_id,
+            session_id=session_id,
+            step_index=1,
+            event_type="tool_call",
+            tool_name="shell",
+            tool_call_id="call_interrupted",
+            tool_input={"command": "pwd"},
+            tool_output={"ok": True, "result": "/workspace"},
+            success=True,
+        )
+
+        history = session_module.history_items_for_provider_restore(
+            store,
+            session_id,
+            messages,
+            provider=provider,
+        )
+
+    assert [item["type"] for item in history] == [
+        "message",
+        "message",
+        "message",
+        "message",
+        "tool_call",
+        "tool_result",
+    ]
+    assert history[2]["message"].content == "interrupted request"
+    assert history[3]["message"].content == "I found the module and will inspect it."
+    assert history[4]["call_id"] == "call_interrupted"
+    assert history[5]["call_id"] == "call_interrupted"
+
+
 @pytest.mark.parametrize(
     ("source_provider", "target_provider"),
     [

--- a/tests/test_web_serve.py
+++ b/tests/test_web_serve.py
@@ -9343,6 +9343,72 @@ def test_saved_session_input_queues_per_turn_tool_history_preference(
     ]
 
 
+@pytest.mark.parametrize("crashed_status", ["interrupted", "stale"])
+def test_crashed_saved_session_automatically_resumes_with_tool_history(
+    tmp_path,
+    monkeypatch,
+    crashed_status,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(SESSION_DB_PATH_ENV, str(tmp_path / "sessions.db"))
+    worker_preferences: list[bool] = []
+    queued_preferences: list[bool] = []
+
+    with SessionStore(db_path=tmp_path / "sessions.db") as store:
+        session_id = store.create_session(
+            str(tmp_path),
+            "openai",
+            "gpt-5.4",
+            "Crashed session",
+        )
+        store.create_run_session(
+            run_session_id="crashed-web-run",
+            session_id=session_id,
+            agent_name="main",
+            agent_type="web_session",
+            provider="openai",
+            provider_id=None,
+            profile_id=None,
+            model="gpt-5.4",
+            status=crashed_status,
+            kind="session",
+        )
+
+    def fake_run_session_loop(
+        _settings,
+        display,
+        *,
+        include_tool_history=False,
+        **kwargs,
+    ):
+        del _settings, kwargs
+        worker_preferences.append(include_tool_history)
+        queued = display.user_prompt()
+        assert isinstance(queued, QueuedInput)
+        queued_preferences.append(queued.include_tool_history)
+        return 0
+
+    manager = WebSessionManager(_settings())
+    try:
+        manager.start()
+        with patch(
+            "pbi_agent.web.session.workers.run_session_loop",
+            fake_run_session_loop,
+        ):
+            result = manager.submit_saved_session_input(
+                session_id,
+                text="Continue from the last completed tool",
+            )
+            worker = manager._live_sessions[str(result["live_session_id"])].worker
+            assert worker is not None
+            worker.join(timeout=2)
+    finally:
+        manager.shutdown()
+
+    assert worker_preferences == [True]
+    assert queued_preferences == [True]
+
+
 def test_project_command_model_profile_overrides_submitted_profile(
     tmp_path,
     monkeypatch,

--- a/uv.lock
+++ b/uv.lock
@@ -473,7 +473,7 @@ wheels = [
 
 [[package]]
 name = "pbi-agent"
-version = "0.28.0"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "codetool-explore" },


### PR DESCRIPTION
## Summary

Release pbi-agent v0.29.0 with reliable continuation of saved sessions interrupted by a server crash or shutdown.

## Highlights

### Fixed

- Restore interrupted user input, intermediate assistant progress, and completed tool exchanges when a saved session continues after restart.
- Exclude incomplete tool calls that have no persisted tool response from provider history.
- Preserve provider-specific history ordering across Responses, Messages, Chat Completions, Google Interactions, and Gemini-compatible histories.

## Changelog

- [docs/changelog/v0.29.0.md](https://github.com/pbi-agent/pbi-agent/blob/chore/release-v0.29.0/docs/changelog/v0.29.0.md)

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run basedpyright`
- [x] `uv run python scripts/dead_code.py`
- [x] `uv run pytest -q --tb=short -x`
- [x] `bun run docs:build`

## Scope

- Includes the local crash-resume fix and the remote post-v0.28.0 bookkeeping commit.
- The bookkeeping commit has no user-facing runtime impact and is omitted from the release highlights.
- No unrelated workspace changes are included.
